### PR TITLE
Get rid of deprecation warning

### DIFF
--- a/opexebo/analysis/autocorrelation.py
+++ b/opexebo/analysis/autocorrelation.py
@@ -53,4 +53,4 @@ def autocorrelation(map):
         d1 = int(aCorr.shape[i] - offset + 1)
         slices.append(slice(d0, d1))
 
-    return aCorr[slices]
+    return aCorr[tuple(slices)]


### PR DESCRIPTION
...\ipykernel_launcher.py:1: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  """Entry point for launching an IPython kernel.