### PR TITLE
Minor fixes to tunng_curve

### DIFF
--- a/opexebo/__init__.py
+++ b/opexebo/__init__.py
@@ -18,4 +18,4 @@ from opexebo import general
 
 __author__ = """Simon Ball"""
 __email__ = 'simon.ball@ntnu.no'
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/opexebo/analysis/tuningCurve.py
+++ b/opexebo/analysis/tuningCurve.py
@@ -58,7 +58,7 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
                       " you can convert with 'np.radians(array)'")
 
     bin_width = kwargs.get("bin_width", default.bin_angle)
-    num_bins = num_bins = int(360. / bin_width)
+    num_bins = np.ceil(360. / bin_width).astype(int)
     if num_bins != angular_occupancy.size:
         raise ValueError("Keyword 'bin_width' must match the value used to"\
                          " generate angular_occupancy")

--- a/opexebo/analysis/tuningCurve.py
+++ b/opexebo/analysis/tuningCurve.py
@@ -47,21 +47,21 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
     occ_ndim = angular_occupancy.ndim
     spk_ndim = spike_angles.ndim
     if occ_ndim != 1:
-        raise ValueError("angular_occupancy must be a 1D array. You provided a\
-                         %d dimensional array" % occ_ndim)
+        raise ValueError("angular_occupancy must be a 1D array. You provided a"\
+                         " %d dimensional array" % occ_ndim)
     if spk_ndim != 1:
-        raise ValueError("spike_angles must be a 1D array. You provided a %d\
-                         dimensional array" % spk_ndim)
+        raise ValueError("spike_angles must be a 1D array. You provided a %d"\
+                         " dimensional array" % spk_ndim)
     if np.nanmax(spike_angles) > 2*np.pi:
-        raise Warning("Angles higher than 2pi detected. Please check that your\
-                      spike_angle array is in radians. If it is in degrees,\
-                      you can convert with 'np.radians(array)'")
+        raise Warning("Angles higher than 2pi detected. Please check that your"\
+                      " spike_angle array is in radians. If it is in degrees,"\
+                      " you can convert with 'np.radians(array)'")
 
     bin_width = kwargs.get("bin_width", default.bin_angle)
     num_bins = num_bins = int(360. / bin_width)
     if num_bins != angular_occupancy.size:
-        raise ValueError("Keyword 'bin_width' must match the value used to \
-                         generate angular_occupancy")
+        raise ValueError("Keyword 'bin_width' must match the value used to"\
+                         " generate angular_occupancy")
 
     spike_histogram, bin_edges = opexebo.general.accumulate_spatial(spike_angles,
                 arena_size=2*np.pi, limits=(0, 2*np.pi), bin_width=bin_width)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.3.2
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,6 @@ setup(
     name='opexebo',
     packages=find_packages(include=['opexebo*']),
     url='https://github.com/kavli-ntnu/opexebo',
-    version='0.3.1',
+    version='0.3.2',
     zip_safe=False,
 )


### PR DESCRIPTION
Where the bin width is not a regular divisor of 360°, AngularOccupancy and TuningCurve would yield different bin numbers for the same width. Bin number calculation has been standardised. 

Version bumped to 0.3.2