### PR TITLE
Bugfixes arising from DJ workshop

### DIFF
--- a/opexebo/analysis/tuningCurve.py
+++ b/opexebo/analysis/tuningCurve.py
@@ -22,7 +22,7 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
         associated with the m'th spike
     kwargs
         bin_width : float
-            width of histogram bin in degrees
+            width of histogram bin in DEGREES
             Must match that used in calculating angular_occupancy
             In the case of a non-exact divisor of 360 deg, the bin size will be 
             shrunk to yield an integer bin number. 
@@ -60,10 +60,16 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
                       " you can convert with 'np.radians(array)'")
 
     bin_width = kwargs.get("bin_width", default.bin_angle)
-    num_bins = np.ceil(360. / bin_width).astype(int)
+    num_bins = np.ceil(360. / bin_width).astype(int) # This is for validation ONLY, the value num_bins here is not passed onwards
     if num_bins != angular_occupancy.size:
         raise ValueError("Keyword 'bin_width' must match the value used to"\
                          " generate angular_occupancy")
+    #UNITS!!!
+    # bin_width and arena_size need to be in the same units. 
+    # As it happens, I hardcoded arena_size as 2pi -> convert bin_width to radians
+    # limits and spike_angles need to be in the same units
+    
+    bin_width = np.radians(bin_width)
 
     spike_histogram, bin_edges = opexebo.general.accumulate_spatial(spike_angles,
                 arena_size=2*np.pi, limits=(0, 2*np.pi), bin_width=bin_width)

--- a/opexebo/analysis/tuningCurve.py
+++ b/opexebo/analysis/tuningCurve.py
@@ -24,6 +24,8 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
         bin_width : float
             width of histogram bin in degrees
             Must match that used in calculating angular_occupancy
+            In the case of a non-exact divisor of 360 deg, the bin size will be 
+            shrunk to yield an integer bin number. 
 
 
     Returns

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -67,6 +67,7 @@ def accumulate_spatial(pos, **kwargs):
                          " provided %d dimensions." % dims)
 
     # Get kwargs values
+    debug = kwargs.get("debug", False)
     bin_width = kwargs.get("bin_width", default.bin_width)
     arena_size = kwargs.get("arena_size")
     limits = kwargs.get("limits", None)
@@ -86,6 +87,8 @@ def accumulate_spatial(pos, **kwargs):
         if limits is None:
             limits = ( [np.nanmin(x), np.nanmax(x)],
                          [np.nanmin(y), np.nanmax(y)] )
+            if debug:
+                print("No limits found. Calculating based on min/max")
         elif len(limits) != 4:
             raise ValueError("You must provide a 4-element 'limits' value for a"\
                              " 2D map. You provided %d elements" % len(limits))
@@ -99,10 +102,29 @@ def accumulate_spatial(pos, **kwargs):
                         np.greater_equal(y, limits[1][0]), np.less(y, limits[1][1])) )
         # the simple operator ">= doesn't respect Masked Arrays
         # As of 2019, it does actually behave correctly (NaN is invalid and so
-        # is removed), but I would prefer to be seplicit
+        # is removed), but I would prefer to be explicit
 
         in_range_x = x[in_range]
         in_range_y = y[in_range]
+        if debug:
+            print(f"Limits: {limits}")
+            print(f"numbins : {num_bins}")
+            print(f"data points : {len(in_range_x)}")
+            # Testing for invalid inputs that have made it past validation
+            # in_range_* should be of non-zero, equal length
+            assert len(in_range_x) == len(in_range_y)
+            assert len(in_range_x) > 0
+            # in_range_* should be all real
+            assert np.isfinite(in_range_x).all()
+            assert np.isfinite(in_range_y).all()
+            # Non zero number of bins
+            assert num_bins[0] > 1
+            assert num_bins[1] > 1
+            # Finite limits
+            assert np.isfinite(np.array(limits)).all()
+
+            
+            
 
         hist, xedges, yedges = np.histogram2d(in_range_x, in_range_y,
                                        bins=num_bins, range=limits)

--- a/opexebo/general/fitEllipse.py
+++ b/opexebo/general/fitEllipse.py
@@ -65,6 +65,12 @@ def fit_ellipse(X, Y):
     if X.size != Y.size:
         raise ValueError("X and Y must be the same length. You provided"\
                          " (%d, %d) values respectively" % (X.size, Y.size))
+    if not np.isfinite(X).all():
+        raise ValueError("X cannot contain values that are nan or inf."\
+                         f" You provided {X}")
+    if not np.isfinite(Y).all():
+        raise ValueError("X cannot contain values that are nan or inf."\
+                         f" You provided {Y}")
     # Normalise the data and move it to the origin
     mx = np.mean(X)
     my = np.mean(Y)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-sep==1.0.3
-astropy==3.1.2
-numpy==1.16.4
-scipy==1.1.0
-scikit-image==0.15.0
+sep>=1.0.3
+astropy>=3.1.2
+numpy>=1.15.0
+scipy>=1.3.0
+scikit-image>=0.15.0


### PR DESCRIPTION
* Loosened restrictions on library versions, particularly NumPy
* Added initial validation of finite input data to `fit_ellipse()`
* Added missing degrees -> radians conversion in `tuning_curve()`

The latter point was causing an oddly intermittant rash of errors, which I *think* arose from, essentially, aliasing the [0, 2pi] range by degree values. In particular, the ephys table HDTuning, was calculating without errors without the degrees-> radians conversion