### PR TITLE
Change behaviour in absence of sep

### DIFF
--- a/opexebo/__init__.py
+++ b/opexebo/__init__.py
@@ -18,4 +18,4 @@ from opexebo import general
 
 __author__ = """Simon Ball"""
 __email__ = 'simon.ball@ntnu.no'
-__version__ = '0.3.3'
+__version__ = '0.3.4'

--- a/opexebo/analysis/gridScore.py
+++ b/opexebo/analysis/gridScore.py
@@ -31,6 +31,8 @@ def grid_score(aCorr, **kwargs):
     **kwargs
         min_orientation : int
             See function "grid_score_stats"
+        search_method : str
+            Peak searching method, currently limited to either `default` or `sep`
 
     Returns
     -------
@@ -192,6 +194,8 @@ def grid_score_stats(aCorr, mask, centre, **kwargs):
             detected in 2D autocorrelation must have. If difference is
             below this threshold, discard the field that has larger
             distance from center
+        search_method : str
+            Peak searching method, currently limited to either `default` or `sep`
 
     Returns
     -------
@@ -223,6 +227,7 @@ def grid_score_stats(aCorr, mask, centre, **kwargs):
     debug = kwargs.get('debug', False)
     min_orientation = kwargs.get('min_orientation', default.min_orientation)
     min_orientation = np.radians(min_orientation)
+    search_method = kwargs.get("search_method", default.search_method) 
     if debug:
         print('Min orientation: {} degrees'.format(np.degrees(min_orientation)))
     
@@ -238,7 +243,7 @@ def grid_score_stats(aCorr, mask, centre, **kwargs):
     gs_spacings         = np.full(3, fill_value = np.nan, dtype=float)
 
     # Find fields in autocorrelogram
-    all_coords = opexebo.general.peak_search(aCorr, mask=mask, search_method="sep",
+    all_coords = opexebo.general.peak_search(aCorr, mask=mask, search_method=search_method,
                                              null_background=True, threshold=0.1)
 
     if all_coords.shape[0] >= 6:
@@ -279,6 +284,7 @@ def grid_score_stats(aCorr, mask, centre, **kwargs):
 
         
         if debug:
+            import matplotlib.pyplot as plt
             aCorr_masked = np.ma.masked_where(mask, aCorr.copy())
             plt.imshow(aCorr_masked)
             plt.scatter(centre[1],centre[0], s=600, marker='x', color='black')

--- a/opexebo/general/peakSearch.py
+++ b/opexebo/general/peakSearch.py
@@ -119,14 +119,16 @@ def _peak_search_sep_wrapper(firing_map, **kwargs):
     with a warning to the user
     
     '''
-    algorithm = _peak_search_sep
     try:
         import sep
+        return _peak_search_sep(firing_map, **kwargs)
     except ModuleNotFoundError:
-        warnings.warn("Package 'sep' not installed in this environment."\
-                      " Using the default peak search algorithm instead")
-        algorithm = _peak_search_skimage
-    return algorithm(firing_map, **kwargs)
+        raise ModuleNotFoundError("The package 'sep' is missing from your system."\
+                " You can invoke an alternative algorithm that does not depend on"\
+                " 'sep' by assigning a different value to 'search_method'."\
+                " Alternatively, install 'sep' on your system:"\
+                " 'pip install sep'")
+    
         
         
 

--- a/opexebo/tests/test_analysis/test_gridScore.py
+++ b/opexebo/tests/test_analysis/test_gridScore.py
@@ -9,6 +9,7 @@ import scipy.io as spio
 import numpy as np
 import pytest
 import inspect
+import matplotlib.pyplot
 
 import test_helpers as th
 from opexebo.analysis import grid_score as func
@@ -35,19 +36,20 @@ def get_acorr_bnt(data, i):
     
 def test_grid_score_similarity():
     data = spio.loadmat(th.test_data_square)
+    print("Data loaded")
     ds = np.arange(th.get_data_size(data))
     vals = np.zeros_like(ds).astype(float)
     for key in ds:
         acorr = get_acorr_bnt(data, key)
         bnt = get_grid_score_bnt(data, key)
-        ope, _ = func(acorr, min_orientation=15, search_method="default")
+        ope, _ = func(acorr, min_orientation=15, search_method="sep")
         if np.isnan(ope):
             ratio = np.abs(bnt/ope-1)
             vals[key] = ratio
-    tol = 1e-5
+    tol = 1e-2
     assert((vals<tol).all())
     print(f"{inspect.stack()[0][3]} passed")
     return True
 
 if __name__ == '__main__':
-    test_grid_score_similarity()
+    pass

--- a/opexebo/tests/test_helpers.py
+++ b/opexebo/tests/test_helpers.py
@@ -2,7 +2,6 @@
 
 test_data_square = r"N:\simoba\opexebo_working_area\test_data\generic\simple_square_input_vars.mat"
 test_data_nonsquare = r"N:\simoba\opexebo_working_area\test_data\non-square\input_file_vars.mat"
-test_data_big = r"C:\Users\simoba\Documents\_work\Kavli\bntComp\Output_2\auto_input_file_vars_2.mat"
 
 
 def get_data_size(data):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.3
+current_version = 0.3.4
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     name='opexebo',
     packages=find_packages(include=['opexebo*']),
     url='https://github.com/kavli-ntnu/opexebo',
-    version='0.3.3',
+    version='0.3.4',
     zip_safe=False,
 )


### PR DESCRIPTION
Change behaviour from 0.3.3:
* `grid_score()` now defaults to `default` instead of `sep`
* If `search_method="sep"`, but `sep` is not installed, then raise a customised ModuleNotFoundError