### PR TITLE
Update RateMap to work with bin_edges

### DIFF
--- a/opexebo/analysis/rateMap.py
+++ b/opexebo/analysis/rateMap.py
@@ -28,7 +28,15 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         occurring with an instaneous speed below the threshold are discarded
     **kwargs
         bin_width : float. 
-            Bin size in cm. Bins are always assumed square default 2.5 cm.
+            Bin size in cm. Bins are always assumed square default 2.5 cm. One
+            of `bin_width`, `bin_number`, `bin_edges` must be provided
+        bin_number: int
+            Number of bins. The same number will be used along both axes,
+            permitting rectangular bins. One of `bin_width`, `bin_number`,
+            `bin_edges` must be provided
+        bin_edges: array-like
+            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`. One
+            of `bin_width`, `bin_number`, `bin_edges` must be provided
         speed_cutoff    : float. 
             Timestamps with instantaneous speed beneath this value are ignored. 
             Default 0
@@ -103,7 +111,7 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         spikes = np.array((spikes_x, spikes_y))
 
     # Histogram of spike positions
-    spike_map = opexebo.general.accumulate_spatial(spikes, **kwargs)[0]
+    spike_map, edges = opexebo.general.accumulate_spatial(spikes, **kwargs)
 
     if spike_map.shape != occupancy_map.shape:
         raise ValueError("Rate Map and Occupancy Map must have the same"\

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -106,9 +106,9 @@ def accumulate_spatial(pos, **kwargs):
                        " can be accepted.")
     elif bool(bin_edges):
         # First priority: use predefined bin_edges
-        # TODO! TODO!
         # Bear in mind that the histogram will be transposed as part of this function
-        # So for the Ratemap
+        # So we have to "pre"-transpose the provided (x_edges, y_edges) to 
+        # (y_edges, x_edges), such that the resulting figure still makes sense
         if is_2d:
             if type(bin_edges) not in (tuple, list, np.ndarray):
                 raise ValueError("keyword 'bin_edges' must be either a tuple or list (of np.ndarrays), or a")

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -19,9 +19,16 @@ def accumulate_spatial(pos, **kwargs):
         This matches the simplest input creation:
             pos = np.array( [x, y] )
    kwargs
-        bin_width       : float.
-            Bin size (in cm). Bins are always assumed square default 2.5 cm.
-        arena_size      : float or tuple of floats.
+        bin_width : float. 
+            Bin size in cm. Bins are always assumed square default 2.5 cm. One
+            of `bin_width`, `bin_number`, `bin_edges` must be provided
+        bin_number: int
+            Number of bins. The same number will be used along both axes,
+            permitting rectangular bins. One of `bin_width`, `bin_number`,
+            `bin_edges` must be provided
+        bin_edges: array-like
+            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`. One
+            of `bin_width`, `bin_number`, `bin_edges` must be provided
             Dimensions of arena (in cm)
             For a linear track, length
             For a circular arena, diameter
@@ -65,10 +72,10 @@ def accumulate_spatial(pos, **kwargs):
     if dims not in (1, 2):
         raise ValueError("pos should have either 1 or 2 dimensions. You have"\
                          " provided %d dimensions." % dims)
-
+    
+    
     # Get kwargs values
     debug = kwargs.get("debug", False)
-    bin_width = kwargs.get("bin_width", default.bin_width)
     arena_size = kwargs.get("arena_size")
     limits = kwargs.get("limits", None)
     if type(limits) not in (tuple, list, np.ndarray, type(None)):
@@ -76,7 +83,52 @@ def accumulate_spatial(pos, **kwargs):
           " (x_min, x_max, y_min, y_max). You provided type %s" % type(limits))
 
     arena_size, is_2d = validatekeyword__arena_size(arena_size, dims)
-    num_bins = np.ceil(arena_size / bin_width).astype(int)
+
+
+    # Handle the decision of bin_edges
+    # Logic:
+        # If none are provided, use default bin_width
+        # If more than 1 is provided, raise Exception
+        # If bin_edges are provided, use them
+        # Else use bin_width, if provided
+        # Else use bin_number, if provided
+    bin_number = kwargs.get("bin_number", False)
+    bin_width = kwargs.get("bin_width", False)
+    bin_edges = kwargs.get("bin_edges", False)
+    if not bin_edges and not bin_width and not bin_number:
+        # No bin decision was provided, so go with default
+        bin_width = default.bin_width
+    elif sum([bool(bin_number), bool(bin_width), bool(bin_edges)]) != 1:
+        # Count the number of values where a value other than False is present
+        # If there are more than 1 "True" value, then the user has provided too many keywords
+        raise KeyError("You have provided more than one method for determining"\
+                       " the edges of the histogram. Only zero or one methods"\
+                       " can be accepted.")
+    elif bool(bin_edges):
+        # First priority: use predefined bin_edges
+        # TODO! TODO!
+        # Bear in mind that the histogram will be transposed as part of this function
+        # So for the Ratemap
+        if is_2d:
+            if type(bin_edges) not in (tuple, list, np.ndarray):
+                raise ValueError("keyword 'bin_edges' must be either a tuple or list (of np.ndarrays), or a")
+        else:
+            if not isinstance(bin_edges, np.ndarray):
+                raise ValueError("Keyword 'bin_edges' must be a numpy array for a 1D histogram")
+        bins = (bin_edges[1], bin_edges[0])
+        debug_bin_type = "bin_edges"
+    elif bool(bin_width):
+        # Calculate the number of bins based on the requested width and arena_size
+        bins = np.ceil(arena_size / bin_width).astype(int)
+        debug_bin_type = "bin_width"
+    elif bool(bin_number):
+        if not isinstance(bin_number, int):
+            raise ValueError("Keyword 'bin_number' must be an integer")
+        bins = bin_number
+        debug_bin_type = "bin_number"
+    
+
+
 
     # Histogram of positions
     
@@ -108,28 +160,14 @@ def accumulate_spatial(pos, **kwargs):
         in_range_y = y[in_range]
         if debug:
             print(f"Limits: {limits}")
-            print(f"numbins : {num_bins}")
+            print(f"Binning type: {debug_bin_type}")
+            print(f"bins : {bins}")
             print(f"data points : {len(in_range_x)}")
-            # Testing for invalid inputs that have made it past validation
-            # in_range_* should be of non-zero, equal length
-            assert len(in_range_x) == len(in_range_y)
-            assert len(in_range_x) > 0
-            # in_range_* should be all real
-            assert np.isfinite(in_range_x).all()
-            assert np.isfinite(in_range_y).all()
-            # Non zero number of bins
-            assert num_bins[0] > 1
-            assert num_bins[1] > 1
-            # Finite limits
-            assert np.isfinite(np.array(limits)).all()
-
-            
-            
 
         hist, xedges, yedges = np.histogram2d(in_range_x, in_range_y,
-                                       bins=num_bins, range=limits)
+                                       bins=bins, range=limits)
         hist = hist.transpose() # Match the format that BNT traditionally used.
-        edges = np.array([yedges, xedges]) # Note that due to the tranposition
+        edges = [yedges, xedges] # Note that due to the tranposition
                             # the label xedge, yedge is potentially misleading
     else:
         x = pos
@@ -142,6 +180,6 @@ def accumulate_spatial(pos, **kwargs):
                                   np.less(x, limits[1]))
         in_range_x = x[in_range]
 
-        hist, edges = np.histogram(in_range_x, bins=num_bins, range=limits)
+        hist, edges = np.histogram(in_range_x, bins=bins, range=limits)
 
     return hist, edges


### PR DESCRIPTION
Currently the logic for calculating the bin edges for the time and spike maps is as follows:
* Take a specified `bin_width` and `arena_size` in cm -> calculate `num_bins`
* Use `num_bins` between `min(x)`, `max(x)` etc.

Since `min(x)` and `max(x)` are calculated from the tracking frames, and the spike positions, respectively, those limits are _different_ between the two maps, and so there is an inappropriate scaling happening. 

This fix allows the spike_map to be calculated with exactly the same bin edges that are returned from the time_map calculation. 