### PR TITLE
fixes to `peak_search`, new `circular_mask` and `upsample`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,10 @@
 #
 import os
 import sys
+import re
 sys.path.insert(0, os.path.abspath('../../opexebo'))
+
+os.environ['MPLBACKEND'] = 'Agg'  # avoid tkinter import errors on rtfd.io
 
 
 # -- Project information -----------------------------------------------------
@@ -24,9 +27,9 @@ copyright = '2019, Simon Ball'
 author = 'Simon Ball'
 
 # The short X.Y version
-version = u'0.2.0'
+version = '0.4.2'
 # The full version, including alpha/beta/rc tags
-release = u'0.2.0'
+release = '0.4.2'
 
 
 # -- General configuration ---------------------------------------------------
@@ -40,15 +43,17 @@ release = u'0.2.0'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
+    'numpydoc',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.mathjax',
+    'sphinx.ext.doctest',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.graphviz',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autosummary'
+    'matplotlib.sphinxext.plot_directive',
+    'IPython.sphinxext.ipython_console_highlighting',
+    'IPython.sphinxext.ipython_directive',
+    'sphinx.ext.imgmath',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,9 +27,9 @@ copyright = '2019, Simon Ball'
 author = 'Simon Ball'
 
 # The short X.Y version
-version = '0.4.2'
+version = 'version = '0.4.3''
 # The full version, including alpha/beta/rc tags
-release = '0.4.2'
+release = 'version = '0.4.3''
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,2 +1,4 @@
 Getting Started
 ===============
+
+Opexebo is available on Github at https://github.com/kavli-ntnu/opexebo

--- a/docs/source/opexebo_analysis.rst
+++ b/docs/source/opexebo_analysis.rst
@@ -18,6 +18,7 @@ Overview
 	opexebo.analysis.place_field
 	opexebo.analysis.autocorrelation
 	opexebo.analysis.grid_score
+	opexebo.analysis.speed_score
 	
 .. rubric:: Angular analysis
 
@@ -25,11 +26,14 @@ Overview
 	opexebo.analysis.angular_occupancy
 	opexebo.analysis.tuning_curve
 	opexebo.analysis.tuning_curve_stats
+
+.. rubric:: Miscellanious
+    opexebo.analysis.population_vector_correlation
+    opexebo.analysis.theta_modulation
 	
 .. rubric:: Experimental
 
 .. autosummary::
-	opexebo.analysis.speed_score
 	opexebo.analysis.border_coverage
 	opexebo.analysis.border_score
 	

--- a/docs/source/opexebo_analysis.rst
+++ b/docs/source/opexebo_analysis.rst
@@ -28,8 +28,10 @@ Overview
 	opexebo.analysis.tuning_curve_stats
 
 .. rubric:: Miscellanious
-    opexebo.analysis.population_vector_correlation
-    opexebo.analysis.theta_modulation
+
+.. autosummary::
+	opexebo.analysis.population_vector_correlation
+	opexebo.analysis.theta_modulation
 	
 .. rubric:: Experimental
 

--- a/docs/source/opexebo_general.rst
+++ b/docs/source/opexebo_general.rst
@@ -17,6 +17,10 @@ Overview
 	opexebo.general.shuffle
 	opexebo.general.normxcorr2_general
 	opexebo.general.fit_ellipse
+    opexebo.general.bin_width_to_bin_number
+    opexebo.general.circular_mask
+    opexebo.power_spectrum
+    opexebo.spatial_cross_correlation
 
 	
 

--- a/docs/source/opexebo_general.rst
+++ b/docs/source/opexebo_general.rst
@@ -11,16 +11,21 @@ Overview
 .. rubric:: Signal processing
 
 .. autosummary::
+    opexebo.general.smooth
+    opexebo.general.upsample
 	opexebo.general.peak_search
-	opexebo.general.accumulate_spatial
-	opexebo.general.smooth
-	opexebo.general.shuffle
-	opexebo.general.normxcorr2_general
-	opexebo.general.fit_ellipse
-    opexebo.general.bin_width_to_bin_number
     opexebo.general.circular_mask
     opexebo.power_spectrum
     opexebo.spatial_cross_correlation
+	opexebo.general.shuffle
+
+.. rubric:: General Helper functions
+
+.. autosummary::
+    opexebo.general.accumulate_spatial
+	opexebo.general.normxcorr2_general
+	opexebo.general.fit_ellipse
+    opexebo.general.bin_width_to_bin_number
 
 	
 

--- a/opexebo/__init__.py
+++ b/opexebo/__init__.py
@@ -13,6 +13,7 @@ defaults
     default values for keyword analysis parameters
 """
 from opexebo import defaults
+from opexebo import errors
 from opexebo import analysis
 from opexebo import general
 

--- a/opexebo/__init__.py
+++ b/opexebo/__init__.py
@@ -19,4 +19,4 @@ from opexebo import general
 
 __author__ = """Simon Ball"""
 __email__ = 'simon.ball@ntnu.no'
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/opexebo/analysis/angularOccupancy.py
+++ b/opexebo/analysis/angularOccupancy.py
@@ -18,9 +18,8 @@ def angular_occupancy(time, angle, **kwargs):
     angle : numpy array
         Head angle in radians
         Nx1 array
-    **kwargs : 
-        bin_width : float
-            Width of histogram bin in degrees
+    bin_width : float, optional
+        Width of histogram bin in degrees
 
     Returns
     -------
@@ -34,7 +33,7 @@ def angular_occupancy(time, angle, **kwargs):
         x, or (x, y), where x, y are 1d np.ndarrays
         Here x, y correspond to the output histogram
     
-    See also
+    Notes
     --------
     Copyright (C) 2019 by Simon Ball, Horst Obenhaus
 

--- a/opexebo/analysis/autocorrelation.py
+++ b/opexebo/analysis/autocorrelation.py
@@ -20,21 +20,18 @@ def autocorrelation(firing_map):
 
     Returns
     -------
-    acorr : np.ndarray
+    acorr: np.ndarray
         Resulting correlation matrix, which is a 2D numpy array.
-        
-    See also
+
+    See Also
     --------
-    BNT.+analyses.autocorrelation
-    
     opexebo.general.normxcorr2_general
         
-    Copyright (C) 2018 by Vadim Frolov
+    Notes
+    -----
+    BNT.+analyses.autocorrelation
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+    Copyright (C) 2018 by Vadim Frolov
     """
 
     # overlap_amount is a parameter that is intentionally not exposed to

--- a/opexebo/analysis/borderCoverage.py
+++ b/opexebo/analysis/borderCoverage.py
@@ -2,142 +2,295 @@
 
 import numpy as np
 from scipy.ndimage import distance_transform_edt
+import cv2
+# TODO TODO TODO
+import matplotlib.pyplot as plt
+
 import opexebo.defaults as default
+from opexebo.general import validate_keyword_arena_shape, circular_mask
+from opexebo.errors import ArgumentError
 
 
-def border_coverage(fields, **kwargs):
+def border_coverage(fields, arena_shape, **kwargs):
     '''
     Calculate border coverage for detected fields.
     
     STATUS : EXPERIMENTAL
     
     This function calculates firing map border coverage that is further
-    used in calculation of a border score.
-
-    TODO
-    I havefollowed the approach used in BNT, but I want to double check whether there 
-    is a better way to do this - it only tells you that *a* field (it doesn't tell 
-    you which one) has coverage of *a* border (it doesn't tell you which one)).
-
-
-    It seems like there should be a better way of doing this
-    (e.g. return a vector of coverage, i.e. a value for each border checked, and 
-    return an index of the best field for each border, or something similar)
+    used in calculation of a border score. Coverage is calculated on a per-field
+    basis, and is therefore dependent on the exact details of the place-field
+    detection algorithm. 
+    
+    Additionally, please be aware of what `top` and `bottom` mean. This function
+    treats `top` as the location where the `y` indicies are greatest. This is
+    the standard convention in a GRAPH ((0,0) at bottom left, `x` increases to
+    right and `y` increases to top). Images are conventionally plotted UPSIDE-
+    DOWN, with `y` increasing towards the bottom.
 
     Parameters
     ----------
-    fields : dict or list of dicts
-        One dictionary per field. Each dictionary must contain the keyword "field_map"
-    **kwargs
-        arena_shape : str
-            accepts: ("square", "rectangle", "rectangular", "rect", "s", "r")
-                    ("circ", "circular", "circle", "c")
-                    ("linear", "line", "l")
-            Rectangular and square are equivalent. Elliptical or n!=4 polygons
-            not currently supported. Defaults to Rectangular
-        search_width : int
-            rate_map and fields_map have masked values, which may occur within the region of border 
-            pixels. To mitigate this, we check rows/columns within search_width pixels of the border
-            If no value is supplied, default 8
-        walls : str
-            Definition of walls along which the border score is calculated. Provided by
-            a string which contains characters that stand for walls:
-                      T - top wall (we assume the bird-eye view on the arena)
-                      R - right wall
-                      B - bottom wall
-                      L - left wall
-            Characters are case insensitive. Default value is 'TRBL' meaning that border
-            score is calculated along all walls. Any combination is possible, e.g.
-            'R' to calculate along right wall, 'BL' to calculate along two walls, e.t.c.
+    fields: dict or list of dicts
+        One dictionary per field. Each dictionary must contain the keyword "map"
+    arena_shape: {"square", "rect", "circle", "line"}
+        Rectangular and square are equivalent. Elliptical or n!=4 polygons
+        not currently supported. Defaults to Rectangular
+    search_width: int
+        rate_map and fields_map have masked values, which may occur within the
+        region of border pixels. To mitigate this, we check rows/columns within
+        search_width pixels of the border Default `8`
+    walls: str or list of tuple
+        Definition of which walls to consider for border coverage. Behaviour is
+        different for different arena shapes
+        * Rectangular arenas
+          type str. The four walls are referred to as `T`, `B`, `R`, `L` for the
+          standard cardinals. Case insensitive. You may include or exclude any
+        * Circular arenas
+          Walls should be specified as a list of inclusive angular start-stop pairs. Angles
+          given in degrees clockwise from top. Both `0` and `360` are permissible
+          values. Start-stop may wrap through zero and may be overlapping with
+          other pairs. Negative angles may be used to express counter-clockwise
+          rotation, and will be automatically wrapped into the [0, 360] range.
+          Example: [(0, 15), (180, 270), (315, 45), (30, 60)]
+          Walls may ALTERNATIVELY be expressed as a string, equivalent to rectangular
+          arenas. In this case, walls will be interpreted as follows
+              * `T` - (315, 45)
+              * `B` - (135, 225)
+              * `L` - (45, 135)
+              * `R` - (225, 315)
+        In either case, defaults `TRBL`. Converting this (or other string) for
+        circluar arrays is handled internally
 
     Returns
     -------
-    coverage    : float
+    coverage: float
         Border coverage, ranges from 0 to 1.
 
-    See also
+    See Also
     --------
-    BNT.+analyses.placefield
-    BNT.+analyses.borderScore
-    BNT.+analyses.borderCoverage
     opexebo.analysis.placefield
     opexebo.analysis.borderscore
-        
+
+    Notes
+    --------
+    * BNT.+analyses.placefield
+    * BNT.+analyses.borderScore
+    * BNT.+analyses.borderCoverage
+
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
-
-    # Extract keyword arguments or set defaults
-    sw = kwargs.get('search_width', default.search_width)
-    walls = kwargs.get('walls', default.walls)
-    shape = kwargs.get("arena_shape", default.shape)
-    if shape.lower() in default.shapes_square:
-        DO_A_THING()
-    elif shape.lower() in default.shapes_circle:
-        DO_A_THING()
-    elif shape.lower() in default.shapes_linear:
-        DO_A_THING()
+    # Process input arguments
+    debug= kwargs.get("debug", False)
+    arena_shape = validate_keyword_arena_shape(arena_shape)
+    
+    if arena_shape in default.shapes_square:
+        calculate_coverage = _calculate_coverage_rect
+    elif arena_shape in default.shapes_circle:
+        calculate_coverage = _calculate_coverage_circ
     else:
-        raise NotImplementedError(f"Arena shape '{shape}' not implemented")
-
-    # Check that the wall definition is valid
-    _validate_wall_definition(walls)
-    walls = walls.lower()
+        raise NotImplementedError(f"Border coverage is not implemented for arena shape `{arena_shape}`")
     
     if isinstance(fields, dict):
         # Deal with the case of being passed a single field, instead of a list of fields
         fields = [fields]
-    elif type(fields) not in (list, tuple, np.ndarray):
+    elif not isinstance(fields, (list, tuple, np.ndarray)):
         raise ValueError(f"You must supply either a dictionary, or list of dictionaries, of fields. You provided type '{type(fields)}'")
+    for i, field in enumerate(fields):
+        if "map" not in field.keys():
+            raise KeyError(f"field dictionary {i} does not have keyword 'map'.")
 
-    # Check coverage of each field in turn
+    # Extract keyword arguments or set defaults
+    search_width = kwargs.get('search_width', default.search_width)
+    walls = kwargs.get('walls', default.walls)
+
+    # Perform validation of the `walls` argument
+    walls = _validate_keyword_walls(walls, arena_shape)
+
+    if debug:
+        print("===== border_coverage =====")
+        print(f"arena_shape: {arena_shape}")
+        print(f"coverage method: {calculate_coverage}")
+        print(f"walls: {walls}")
+        print(f"num fields: {len(fields)}")
+
     coverage = 0
     for field in fields:
-        fmap = field['field_map'] # binary image of field: values are 1 inside field, 0 outside
-        if "l" in walls:
-            aux_map = fmap[:,:sw].copy()
-            c = _wall_field_rect(aux_map)
-            if c > coverage:
-                coverage = c
-
-        if "r" in walls:
-            aux_map = fmap[:, -sw:].copy()
-            aux_map = np.fliplr(aux_map) # Mirror image to match the expectations in _wall_field, i.e. border adjacent to left-most column
-            c = _wall_field_rect(aux_map)
-            if c > coverage:
-                coverage = c
-
-        # since we are dealing with data that came from a camera
-        #'bottom' is actually at the top of the matrix fmap
-        # i.e. in a printed array (think Excel spreadheet), [0,0] is at top-left.
-        # in a figure (think graph) (0,0) is at bottom-left
-
-        # Note: because I use rotations instead of transposition, this yields 
-        # arrays that are upside-down compared to Vadim's version, 
-        # BUT the left/right is correct.
-        if "b" in walls:
-            aux_map = fmap[:sw, :].copy()
-            aux_map = np.rot90(aux_map) # Rotate counterclockwise - top of image moves to left of image
-            c = _wall_field_rect(aux_map)
-            if c > coverage:
-                coverage = c
-
-        if "t" in walls:
-            aux_map = fmap[-sw:, :].copy()
-            aux_map = np.fliplr(np.rot90(aux_map)) # rotate 90 deg counter clockwise (bottom to right), then mirror image
-            c = _wall_field_rect(aux_map)
-            if c > coverage:
-                coverage = c
+        fmap = field["map"]
+        for wall in walls:
+            c = calculate_coverage(fmap, wall, search_width, debug)
+            coverage = max(coverage, c)
+    
     return coverage
 
 
-def _wall_field_rect(wfmap):
-    '''Evaluate what fraction of the border area is covered by a single field in
-    a rectangular or square arena
+###############################################################################
+####            Helper functions : CIRCULAR arenas
+###############################################################################
+
+
+
+def _calculate_coverage_circ(fmap, wall, search_width, debug):
+    '''
+    Evaluate what fraction of the border area is covered by a single field in a
+    circular arena
+    
+    Problems to solve:
+        * Identify where the border actually is, since we can't just use the
+          edge of the array
+        * Convert the cartesian co-ordinates of the field map to polar co-ordinates
+        * Isolate the relevant arc
+    First point: we can _start_ by assuming that the circle is centred on the
+    centre of the array. I'm not convinced that this is a good approximation, but
+    it's a place to start
+    
+    Parameters
+    ----------
+    fmap : np.ndarray or np.ma.MaskedArray
+        Binary map of specific firing field
+    '''
+    if not isinstance(fmap, np.ma.MaskedArray):
+        fmap = np.ma.asanyarray(fmap)
+    fmap = fmap.copy() # create a separate copy to work on, to avoid propagating changes back outside this function
+    
+    # Create a border wall mask, and a distance map
+    # use cv2 to 
+    raise NotImplementedError
+    # Below - using cv2 to find the minimum enclosing circular contour
+    # The trouble is this only works on the _entire_ ratemap (and it seems to work fairly well)
+    # It won't work at all on single fields. 
+    # At least it would need to be run on the entire, summed, fields_map. 
+    # Better still, it would be run on the ratemap. 
+    '''
+    fmap_threshold = np.uint8(fmap>0)
+    centres = cv2.findContours(fmap_threshold, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2]
+    x = y = radius = 0
+    for c in centres:
+        (x_, y_), r_ = cv2.minEnclosingCircle(c)
+        if r_ > radius:
+            x = x_
+            y = y_
+            radius = r_
+    axes = [np.arange(0, fmap.shape[i]+1, 1) for i in [0,1]]
+    circle_mask, distance, angle = circular_mask(axes, radius*2, origin=(x, y))
+    
+    if debug:
+        print(f"radius (bins): {radius}")
+    '''
+    
+    
+
+    
+    # Circular_mask gives us nearly everything we need: an array of distances (in floating-point bins)
+    # and a separate array of angles (in degrees, with 0 pointing to y_max, and 90° pointing to x_max)
+    # We can use these as lookups to convert to polar co-ordinates
+    
+    
+    # Construct a mask for locations we do care about, based on angle, 
+    # distance_from_border, and whether it is inside the circle
+    if wall[0] > wall[1]:
+        good_arc = np.logical_or(np.logical_and(wall[0] <= angle,
+                                                angle <= 360),
+                                 np.logical_and(0 <= angle,
+                                                angle <= wall[1]))
+    else:
+        good_arc = np.logical_and(wall[0] <= angle,
+                                  angle <= wall[1])
+    
+    border_distance = radius - distance
+    good_distance = np.logical_and(0 <= border_distance,
+                                   border_distance <= search_width)
+    
+    in_region = np.logical_and(circle_mask, good_arc, good_distance)
+    not_in_region = np.logical_not(in_region)
+    
+    # Using this mask, blank out all the locations that are not relevant
+    # "Blanking out" the border_distance array , means set it to high values, not low
+    fmap[not_in_region] = 0
+    border_distance[not_in_region] = np.max(border_distance)
+    
+    # Plan
+        # Iterate across all locations within `in_region`, low to high, sorted by `border_distance`
+        # Locations which round (floor) down to zero will potentially count towards coverage
+            # To count towards coverage, they must be part of a field
+            # Alternatively, if they are NaN in `fmap` (never visited), then find the next nearest in along that angle, and repeat the check
+
+
+
+
+    def _circular_inwards_search(idx, i):
+        '''
+        If an unvisited location is found, recursively search inwards until either
+        search_width is reached, or a visited location is found. If a visited location
+        is found, at nearly the same angle, then swap the values in field_map
+        
+        This recursive loop is only started where `border_distance_int`==0, so start
+        searching where `border_distance_int` == 1, and recursively allow it to rise, 
+        until the value at the closest angle is NOT a NaN
+        '''
+        nonlocal fmap
+        nonlocal border_distance
+        nonlocal border_distance_int
+        nonlocal angle
+        nonlocal in_region
+        nonlocal search_width
+        
+        if i == search_width:
+            # Recurse at most `search_width` times
+            return None
+        
+        locations_to_search = (border_distance_int == i)
+        try:
+            idx_2 = np.argmin(np.abs(angle[locations_to_search] - angle[idx]))
+        except ValueError:
+            # if the sequence is empty, try the next i
+            _circular_inwards_search(idx, i+1)
+        if np.isnan(fmap[idx_2]):
+            # If this location is NaN as well, try the next i
+            _circular_inwards_search(idx, i+1)
+        else:
+            # If not NaN, then swap the values, and return to the main loop
+            fmap[idx] = fmap[idx_2]
+
+
+    
+    border_distance_int = np.floor(border_distance)
+    # sort by border_distance and then work with co-ordinates to index between the three arrays (fmap, border_distance, angle)
+    locations_to_search =  np.argwhere(border_distance_int == 0)
+    if debug:
+        fig, ax = plt.subplots(ncols=2)
+        ax[0].imshow(fmap)
+        ax[1].imshow(border_distance_int)
+
+    for row, col in locations_to_search:
+        idx = (row, col)
+        if np.isnan(fmap[idx]):
+            # Do some shuffling
+            # TODO
+            _circular_inwards_search(idx, 1)
+            pass
+        if fmap[idx]:   # i.e. is part of the field, after shuffling
+            # do nothing, leave it as a zero for the final count
+            pass
+        else:           # i.e. not part of the field
+            # Set the value in border_distance_int to non-zero, so it will not be counted
+            border_distance_int[idx] = np.max(border_distance_int)
+    
+    # Coverage is determined by the ratio of locations with distance 0 to the number covered by the field in question    
+    coverage = np.count_nonzero(border_distance_int==0) / np.max(locations_to_search.shape)
+            
+    return coverage
+    
+    
+    
+###############################################################################
+####            Helper functions : RECTANGULAR arenas
+###############################################################################
+
+
+def _calculate_coverage_rect(fmap, wall, search_width, debug):
+    '''
+    Evaluate what fraction of the border area is covered by a single field in a
+    rectangular or square arena
 
     Border coverage is provided as two values: 
         covered : the sum of the values across all sites immediately adjacent 
@@ -154,15 +307,36 @@ def _wall_field_rect(wfmap):
     and where the 0th column (wfmap[:,0], len()=N) repsents the sites closest 
     to the border
 
-    wfmap: has value 1 inside the field and 0 outside the field
+    fmap: has value 1 inside the field and 0 outside the field
+    
+    Parameters
+    ----------
+    fmap : np.ndarray or np.ma.MaskedArray
+        Binary map of a sngle firing field (as supplied by `opexebo.analysis.place_field`).
+    wall : str
+        Which wall to consider for coverage. Call this function multiple times
+        to consider multiple walls
+    search_width : int
+        Width of the region from the border inwards to consider for calculation
+        
+    
+    Returns
+    -------
+    coverage : float
+        Coverage of the relevant border. Coverage is maximised for an infinitely
+        narrow field extending over the entire width of the border. Thicker fields
+        that cover less of the border width have reduced coverage. 
     '''
+    # fmap is the input field
+    # wfmap is the isolated and rotated section to search
+    wfmap = _get_aux_map_rect(fmap, wall, search_width)
+    
     if type(wfmap) != np.ma.MaskedArray:
         wfmap = np.ma.asanyarray(wfmap)
-    N = wfmap.shape[0]
-    wfmap[wfmap>1] = 1 # Just in case a still-labelled map has crept in
-    inverted_wfmap = 1-wfmap 
+    wfmap[np.ma.greater(wfmap, 1)] = 1 # Just in case a still-labelled map has crept in
+    inverted_wfmap = 1 - wfmap 
     distance = distance_transform_edt(np.nan_to_num(inverted_wfmap.data, copy=True)) # scipy doesn't recognise masks
-    distance = np.ma.masked_where(wfmap.mask, distance) # Preserve masking
+    distance = np.ma.masked_where(np.ma.getmaskarray(wfmap), distance) # Preserve masking
     # distance_transform_edt(1-map) is the Python equivalent to (Matlab bwdist(map))
     # Cells in map with value 1 go to value 0
     # Cells in map with value 0 go to the geometric distance to the nearest value 1 in map
@@ -180,34 +354,122 @@ def _wall_field_rect(wfmap):
                         adjacent_sites.mask[i] = False
                         break
     covered = np.ma.sum(adjacent_sites==0)
-    contributing_cells = N - np.sum(adjacent_sites.mask) # The sum gives the number of remaining inf, nan or masked cells
-
+    contributing_cells = wfmap.shape[0] - np.sum(adjacent_sites.mask) # The sum gives the number of remaining inf, nan or masked cells
     coverage = covered / contributing_cells
-
     return coverage
 
-def _wall_field_circ(wfmap):
-    '''
-    Evaluate what fraction of the border area is covered by a single field in a
-    circular arena
-    '''
-    raise NotImplementedError
 
 
-def _validate_wall_definition(walls):
-    '''Parse the walls argument for invalid entry'''
-    if not isinstance(walls, str):
-        raise ValueError("Wall definition must be given as a string, e.g." \
-                         "'trbl'. %s is not a valid input." % str(walls))
-    elif len(walls) > 4:
-        raise ValueError("Wall definition may not exceed 4 characters. String"\
-                         " '%s' contains %d characters." % (walls, len(walls)))
-    elif len(walls) == 0:
-        raise ValueError("Wall definition must contain at least 1 character"\
-                         "from the set [t, r, b, l]")
+def _get_aux_map_rect(fmap, wall, search_width):
+    '''
+    Isolate the appropriate section of a map (determined by `search_width`), and
+    rotate it so that the relevant portion, and the border are at left most 
+    (i.e. minimum `x` index)
+    
+    !! WARNING !! This function treats "top" as "the values where the `y` index is greatest.
+    THIS DOES NOT NECESSARILY MEAN THE TOP OF THE IMAGE!
+    
+    Conventionally, a graph is plotted with (x=0, y=0) at BOTTOM left. X increases
+    towards the right, and Y increases towards the top
+    
+    Conventionally an image is plotted flipped up/down, with (0,0) at TOP left,
+    and Y increases towards the BOTTOM
+    '''
+    # Get our "auxiliary" map from the provided firing map
+    # That means pick out the particular section determined by `search_width`
+    # And rotate as determined by `wall`, so that the relevant border and pixels 
+    # are always at the left-most of the image
+    
+    if wall == "l":
+        aux_map = fmap[:,:search_width].copy()
+    elif wall == "r":
+        # Mirror image to match the expectations in _wall_field, i.e. border adjacent to left-most column
+        aux_map = fmap[:, -search_width:].copy()
+        aux_map = np.fliplr(aux_map)
+    elif wall == "t":
+        # rotate 90 deg counter clockwise (bottom to right), then mirror image
+        aux_map = fmap[-search_width:, :].copy()
+        aux_map = np.rot90(aux_map)
+        aux_map = np.fliplr(aux_map)
+    elif wall == "b":
+        # Rotate counterclockwise - top of image moves to left of image
+        aux_map = fmap[:search_width, :].copy()
+        aux_map = np.rot90(aux_map)
     else:
-        walls = walls.lower()
+        # This should never happen
+        raise ValueError
+    return aux_map
+
+
+
+
+
+###############################################################################
+####            Helper functions : Misc
+###############################################################################
+
+def _validate_keyword_walls(walls, shape):
+    '''Parse the walls keyword to be sure that it is valid and conforms to requirements.
+    Logic is complicated due to the wildly diverging approach of the square and circular arena shapes
+    
+    Parameters
+    ----------
+    walls : keyword value given to border_coverage `walls`
+    shape : keyword value given to border_coverage `arena_shape`
+    
+    Returns
+    -------
+    walls : str or list of np.ndarrays
+        Appropriate form given the `shape` parameter
+    
+    '''
+    
+    if isinstance(walls, str):
+        # do string-related stuff
+        # Check that only acceptable characters are included
+        # Remove duplicates and set to lowercase
+        walls = "".join(sorted(set(walls.lower())))
+        # Note: set() can break ordering. sorting still breaks ordering, but makes it consistent
+        if not (0 < len(walls) <= 4):
+            raise ValueError("keyword `walls` as a string must contain 1-4 characters."\
+                             f" You provided {len(walls)} characters")
         for char in walls:
-            if char.lower() not in ["t","r","b","l"]:
-                raise ValueError("Character %s is not a valid entry in wall"\
-                                 "definition. Valid characters are [t, r, b, l]" % char)
+            if char not in ["t","r","b","l"]:
+                 raise ValueError("Character %s is not a valid entry in wall"\
+                                  " definition. Valid characters are [t, r, b, l]" % char)
+        # If the arena_shape is circular, convert this to the requisite angular form
+        if shape in default.shapes_circle:
+            walls_new = []
+            for char in walls:
+                if char == "t":
+                    walls_new.append((315, 45))
+                elif char == "b":
+                    walls_new.append((135, 225))
+                elif char == "l":
+                    walls_new.append((45, 135))
+                elif char == "r":
+                    walls_new.append((225, 315))
+            walls = walls_new
+
+    elif isinstance(walls, (list, tuple, np.ndarray)):
+        if shape in default.shapes_square:
+            raise ArgumentError("Keyword `walls` is the wrong type for a rectangular"\
+                                " arena. You must provide a string definition")
+        for i, element in enumerate(walls):
+            if not isinstance(element, (list, tuple, np.adarray)):
+                raise ValueError("Keyword `walls` as an array-like must contain array-like"\
+                                 f" start-stop pairs. Element {i} has type `{type(element)}`")
+            if not len(element) == 2:
+                raise ValueError("Keyword `walls` as an array-like must contain array-like"\
+                                 f" start-stop pairs. Element {i} has length `{len(element)}`")
+            # Ensure that values are wrapped into [0, 360]
+            # Ensure that values are ordered (smaller, larger)
+            new_element = np.array(sorted(element)) % 360
+            walls[i] = new_element
+
+    else:
+        raise ArgumentError("Keyword `wall` definition is the wrong type. You"\
+                            "must provide a string (for rectangular or circular arrays),"\
+                            " or a list of angular start-stop lists for circular arrays")
+
+    return walls

--- a/opexebo/analysis/borderScore.py
+++ b/opexebo/analysis/borderScore.py
@@ -35,62 +35,54 @@ def border_score(rate_map, fields_map, fields, **kwargs):
     
     Parameters
     ----------
-    rate_map    :   np.ma.MaskedArray
+    rate_map:   np.ma.MaskedArray
         rate map: N x M array where each cell value is the firing rate of the cell
-    fields_map  :   np.ma.MaskedArray
+    fields_map:   np.ma.MaskedArray
         Integer array of labelled fields. Each cell value is a positive integer. 
         Cells that are members of field have the value corresponding to field_id 
         (non-zero positive  unique integers. Not necessarily contiguous 
         (e.g. 1, 2, 3, 5)). Cells that are not members of fields have value zero
-    fields      :  list of  dict
+    fields:  list of  dict
         List of dictionaries of firing fields. 
         Each dictionary must, at least, contain the keyword "field_map", yielding a 
         binary map of that field within the overall arena
-    kwargs
-        arena_shape : str
-            accepts: ("square", "rectangle", "rectangular", "rect", "s", "r")
-                    ("circ", "circular", "circle", "c")
-                    ("linear", "line", "l")
-            Rectangular and square are equivalent. Elliptical or n!=4 polygons
-            not currently supported. Defaults to Rectangular
-        search_width : int
-            rate_map and fields_map have masked values, which may occur within 
-            the region of border  pixels. To mitigate this, we check rows/columns
-            within search_width pixels of the border.
-            If no value is supplied, default 8
-        walls : str
-            Definition of walls along which the border score is calculated. Provided by
-            a string which contains characters that stand for walls:
-                      T - top wall (we assume the bird-eye view on the arena)
-                      R - right wall
-                      B - bottom wall
-                      L - left wall
-                      Characters are case insensitive. Default value is 'TRBL' 
-                      meaning that border score is calculated along all walls.
-                      Any combination is possible, e.g.  'R' to calculate along
-                      right wall, 'BL' to calculate along two walls, e.t.c.
+    arena_shape: {"square", "rect", "circle", "line"}
+        Rectangular and square are equivalent. Elliptical or n!=4 polygons
+        not currently supported. Defaults to Rectangular
+    search_width: int
+        rate_map and fields_map have masked values, which may occur within 
+        the region of border  pixels. To mitigate this, we check rows/columns
+        within search_width pixels of the border.
+        If no value is supplied, default 8
+    walls: str
+        Definition of walls along which the border score is calculated. Provided by
+        a string which contains characters that stand for walls:
+                  * T - top wall (we assume the bird-eye view on the arena)
+                  * R - right wall
+                  * B - bottom wall
+                  * L - left wall
+        Characters are case insensitive. Default value is 'TRBL' meaning that border
+        score is calculated along all walls. Any combination is possible, e.g.
+        'R' to calculate along right wall, 'BL' to calculate along two walls, e.t.c.
 
     Returns
     -------
-    score   : float
+    score: float
         Border score in the range [-1, 1].
         A value of -1 is given when no fields are provided
 
-
-    See also
+    See Also
     --------
-    BNT.+analyses.placefield
-    BNT.+analyses.borderScore
-    BNT.+analyses.borderCoverage
     opexebo.analysis.placefield
     opexebo.analysis.bordercoverage
+
+    Notes
+    -----
+    * BNT.+analyses.placefield
+    * BNT.+analyses.borderScore
+    * BNT.+analyses.borderCoverage
         
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
 
     # Check that fields exist

--- a/opexebo/analysis/borderScore.py
+++ b/opexebo/analysis/borderScore.py
@@ -1,12 +1,16 @@
 """Provide function for calculating a Border Score"""
 
+import cv2
 import numpy as np
 from scipy.ndimage import distance_transform_cdt
+
+
 from opexebo.analysis import border_coverage
+from opexebo.general import validate_keyword_arena_shape, circular_mask
 import opexebo.defaults as default
 
 
-def border_score(rate_map, fields_map, fields, **kwargs):
+def border_score(rate_map, fields_map, fields, arena_shape, **kwargs):
     '''
     Calculate border score for a firing map
     
@@ -48,28 +52,42 @@ def border_score(rate_map, fields_map, fields, **kwargs):
         binary map of that field within the overall arena
     arena_shape: {"square", "rect", "circle", "line"}
         Rectangular and square are equivalent. Elliptical or n!=4 polygons
-        not currently supported. Defaults to Rectangular
-    search_width: int
-        rate_map and fields_map have masked values, which may occur within 
-        the region of border  pixels. To mitigate this, we check rows/columns
-        within search_width pixels of the border.
-        If no value is supplied, default 8
-    walls: str
-        Definition of walls along which the border score is calculated. Provided by
-        a string which contains characters that stand for walls:
-                  * T - top wall (we assume the bird-eye view on the arena)
-                  * R - right wall
-                  * B - bottom wall
-                  * L - left wall
-        Characters are case insensitive. Default value is 'TRBL' meaning that border
-        score is calculated along all walls. Any combination is possible, e.g.
-        'R' to calculate along right wall, 'BL' to calculate along two walls, e.t.c.
+        not currently supported.
+    search_width: int, optional
+        rate_map and fields_map have masked values, which may occur within the
+        region of border pixels. To mitigate this, we check rows/columns within
+        search_width pixels of the border Default `8`
+    walls: str or list of tuple, optional
+        Definition of which walls to consider for border coverage. Behaviour is
+        different for different arena shapes
+        * Rectangular arenas
+          type str. The four walls are referred to as `T`, `B`, `R`, `L` for the
+          standard cardinals. Case insensitive. You may include or exclude any
+        * Circular arenas
+          Walls should be specified as a list of inclusive angular start-stop pairs. Angles
+          given in degrees clockwise from top. Both `0` and `360` are permissible
+          values. Start-stop may wrap through zero and may be overlapping with
+          other pairs. Negative angles may be used to express counter-clockwise
+          rotation, and will be automatically wrapped into the [0, 360] range.
+          Example: [(0, 15), (180, 270), (315, 45), (30, 60)]
+          Walls may ALTERNATIVELY be expressed as a string, equivalent to rectangular
+          arenas. In this case, walls will be interpreted as follows
+              * `T` - (315, 45)
+              * `B` - (135, 225)
+              * `L` - (45, 135)
+              * `R` - (225, 315)
+        In either case, defaults `TRBL`. Converting this (or other string) for
+        circluar arrays is handled internally
 
     Returns
     -------
     score: float
         Border score in the range [-1, 1].
         A value of -1 is given when no fields are provided
+    coverage: float
+        Border coverage in the range [0, 1]
+        The coverage is given for ONE border. Coverage for a specific wall is
+        only available if a single wall is searched
 
     See Also
     --------
@@ -84,33 +102,50 @@ def border_score(rate_map, fields_map, fields, **kwargs):
         
     Copyright (C) 2019 by Simon Ball
     '''
+    arena_shape = validate_keyword_arena_shape(arena_shape)
 
     # Check that fields exist
     if np.ma.max(fields_map) == 0:
         # No fields exist
-        score = -1
-    else:
-        # 1 or more fields exist
-        fields_map_unlabelled = np.copy(fields_map)
-        fields_map_unlabelled[fields_map>1] = 1
-        coverage = border_coverage(fields, **kwargs)
-        fields_rate_map = fields_map_unlabelled * rate_map
-        fields_rate_map = np.ma.masked_invalid(fields_rate_map)
-        wfd = _weighted_firing_distance(fields_rate_map)
-        score = (coverage - wfd)/(coverage + wfd)
-    return score
+        return -1, 0
+    
+    # 1 or more fields exist
+    fields_map_unlabelled = np.copy(fields_map)
+    fields_map_unlabelled[fields_map> 1 ] = 1
+
+    coverage = border_coverage(fields, arena_shape, **kwargs)
+
+    fields_rate_map = fields_map_unlabelled * rate_map
+    fields_rate_map = np.ma.masked_invalid(fields_rate_map)
+
+    wfd = _weighted_firing_distance(fields_rate_map, arena_shape)
+
+    score = (coverage - wfd)/(coverage + wfd)
+    return score, coverage
 
 
-def _weighted_firing_distance(rmap):
+
+###############################################################################
+####            Border Score helper functions
+###############################################################################
+
+
+def _weighted_firing_distance(rmap, arena_shape):
     '''
-    parameters
-    ---
-    rmap    : np.ma.MaskedArray
+    Calculate the weighted firing distance
+    
+    A perfect border cell is one that fires only (and always) when the animal is
+    imemdiately adjacent to a border. This function weights the firing rate
+    reported in the ratemap by its proximity to the border.
+
+    Parameters
+    ----------
+    rmap: np.ma.MaskedArray
         Rate map of cells inside fields. NxM array where cells inside fields
         give the firing rate, and cells outside fields are zero
-    returns
+    Returns
     -------
-    wfd     : float
+    wfd: float
         Weighted firing distance. 
     '''
     # Check that the provided array is properly masked
@@ -130,3 +165,52 @@ def _weighted_firing_distance(rmap):
     # Normalise by half of the smallest arena dimensions
     wfd = 2 * wfd / np.min(rmap.shape)
     return wfd
+
+
+
+def _identify_border(rmap, arena_shape, debug=False):
+    '''
+    Identify the border based on the arena_shape. This is needed to cope with
+    circular arenas
+    
+    Parameters
+    ----------
+    rmap: np.ndarray or np.ma.MaskedArray
+        Rate map of the unit
+    arena_shape: {"square", "rect", "circle", "line"}
+        Rectangular and square are equivalent. Elliptical or n!=4 polygons
+        not currently supported.
+    
+    Returns
+    -------
+    dict
+        mask: np.ndarray
+            Boolean array. `True` inside arena, `False` outside
+        distance: np.ndarray, optional
+            [Circular arenas only] Array of distances from the border
+        angle: np.ndarray, optional
+            [Circular arenas only] Array of angles from the centre. 
+    '''
+    out = {}
+    if arena_shape in default.shapes_square:
+        mask = np.ones(rmap.shape, dtype=bool)
+        out["mask"] = mask
+    elif arena_shape in default.shapes_circle:
+        rmap_threshold = np.uint8(rmap>0)
+        centres = cv2.findContours(rmap_threshold, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2]
+        x = y = radius = 0
+        for c in centres:
+            (x_, y_), r_ = cv2.minEnclosingCircle(c)
+            if r_ > radius:
+                x = x_
+                y = y_
+                radius = r_
+        axes = [np.arange(0, rmap.shape[i]+1, 1) for i in [0,1]]
+        mask, distance, angle = circular_mask(axes, radius*2, origin=(x, y))
+        out["mask"] = mask
+        out["distance"] = radius - distance
+        out["angle"] = angle
+        if debug:
+            print(f"radius (bins): {radius}")
+    return out
+        

--- a/opexebo/analysis/gridScore.py
+++ b/opexebo/analysis/gridScore.py
@@ -42,63 +42,60 @@ def grid_score(aCorr, **kwargs):
     ----------
     acorr: np.ndarray
         A 2D autocorrelogram.
-    **kwargs
-        min_orientation : int
-            See function "grid_score_stats"
-        search_method : str
-            Peak searching method, currently limited to either `default` or `sep`
-        bin_width : float
-            Size of the bins. Distance units will be returned in the same units
-            If not provided, distance units will be retuned in units [bins]
+    
+    Other Parameters
+    ----------------
+    min_orientation: int
+        See function "grid_score_stats"
+    search_method: str
+        Peak searching method, currently limited to either `default` or `sep`
+    bin_width: float
+        Size of the bins. Distance units will be returned in the same units
+        If not provided, distance units will be retuned in units [bins]
 
     Returns
     -------
-    grid_score : float
+    grid_score: float
         Always returns a gridness score value. It ranges from -2 to 2. 2 is
         more of a theoretical bound for a perfect grid. More practical value for
         a good grid is around 1.3. If function can not calculate a gridness
         score, NaN value is returned.
-    grid_stats : dictionary
-        grid_spacings              : np.array
+    grid_stats: dictionary
+        grid_spacings: np.array
             Spacing of three adjacent fields closest to center in autocorr
             (in [bins] if keyword `bin_width` is not given)
-        grid_spacing                : float
+        grid_spacing: float
             Nanmean of 'spacings' (in [bins] if keyword `bin_width` is not
             given)
-        grid_orientations           : np.array
+        grid_orientations: np.array
             Orientation of three adjacent fields closest to center in autocorr
             (in [degrees])
-        grid_orientations_std       : float
+        grid_orientations_std: float
             Standard deviation of orientations % 60
-        grid_orientation            : float
+        grid_orientation: float
             Orientation of grid in [degrees] (mean of fields of 3 main axes)
-        grid_positions              : np.array
+        grid_positions: np.array
             [y,x] coordinates of six fields closest to center
-        grid_ellipse                : np.array
+        grid_ellipse: np.array
             Ellipse fit returning 
             [x coordinate, y coordinate, major radius, minor radius, theta]
-        grid_ellipse_aspect_ratio   : float
+        grid_ellipse_aspect_ratio: float
             Ellipse aspect ratio (major radius / minor radius)
-        grid_ellipse_theta          : float
+        grid_ellipse_thet: float
             Ellipse theta (corrected according to previous BNT standard) in [degrees]
 
     See Also
     --------
-    BNT.+analyses.gridnessScore
-    
     opexebo.analysis.placefield
 
-    Copyright (C) 2018 by Vadim Frolov, (C) 2019 by Simon Ball, Horst Obenhaus
+    Notes
+    -----
+    BNT.+analyses.gridnessScore
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+    Copyright (C) 2018 by Vadim Frolov, (C) 2019 by Simon Ball, Horst Obenhaus
     """
-    # Arrange keyword arguments
-#    fieldThreshold = kwargs.get("field_threshold", default.field_threshold)
-#    minOrientation = kwargs.get("min_orientation", default.min_orientation)
     debug = kwargs.get("debug", False)
+
     # normalize aCorr in order to find contours
     aCorr = aCorr / aCorr.max()
     centre = -0.5 + np.array(aCorr.shape)/2 # centre : also [y, x]

--- a/opexebo/analysis/placeField.py
+++ b/opexebo/analysis/placeField.py
@@ -22,51 +22,52 @@ def place_field(firing_map, **kwargs):
 
     Parameters
     ----------
-    firing_map : np.ndarray or np.ma.MaskedArray
+    firing_map: np.ndarray or np.ma.MaskedArray
         smoothed rate map.
         If supplied as an np.ndarray, it is assumed that the map takes values
         of np.nan at locations of zero occupancy. If supplied as an np.ma.MaskedArray,
         it is assumed that the map is masked at locations of zero occupancy
-    **kwargs
-        min_bins : int
-            Fields containing fewer than this many bins will be discarded.
-            Default 9
-        min_peak : float
-            Fields with a peak firing rate lower than this absolute value will
-            be discarded. Default 1 Hz
-        min_mean : float
-            Fields with a mean firing rate lower than this absolute value will
-            be discarded. Default 0 Hz
-        init_thresh : float
-            Initial threshold to search for fields from. Must be in the range [0, 1].
-            Default 0.96
-        search_method : str
-            Peak detection finding method. By default, use skimage.morphology.local_maxima
-            Acceptable values are defined in opexebo.defaults.
-            Not required if peak_coords are provided
-        peak_coords : array-like
-            List of peak co-ordinates to consider instead of auto detection
-            Default None
+    
+    Other Parameters
+    ----------------
+    min_bins: int
+        Fields containing fewer than this many bins will be discarded. Default 9
+    min_peak: float
+        Fields with a peak firing rate lower than this absolute value will
+        be discarded. Default 1 Hz
+    min_mean: float
+        Fields with a mean firing rate lower than this absolute value will
+        be discarded. Default 0 Hz
+    init_thresh: float
+        Initial threshold to search for fields from. Must be in the range [0, 1].
+        Default 0.96
+    search_method: str
+        Peak detection finding method. By default, use `skimage.morphology.local_maxima`
+        Acceptable values are defined in `opexebo.defaults`. Not required if 
+        peak_coords are provided
+    peak_coords: array-like
+        List of peak co-ordinates to consider instead of auto detection. [y, x].
+        Default None
 
     Returns
     -------
-    fields : list (of dict)
-        coords : np.ndarray
+    fields: list of dict
+        coords: np.ndarray
             Coordinates of all bins in the firing field
-        peak_coords : np.ndarray
+        peak_coords: np.ndarray
             Coordinates peak firing rate [y,x]
         centroid_coords: np.ndarray
             Coordinates of centroid (decimal) [y,x]
-        area : int
+        area: int
             Number of bins in firing field. [bins]
-        bbox : tuple
+        bbox: tuple
             Coordinates of bounding box including the firing field
             (y_min, x_min, y_max, y_max)
-        mean_rate : float
+        mean_rate: float
             mean firing rate [Hz]
-        peak_rate : float
+        peak_rate: float
             peak firing rate [Hz]
-        map : np.ndarray
+        map: np.ndarray
             Binary map of arena. Cells inside firing field have value 1, all
             other cells have value 0
     fields_map : np.ndarray
@@ -79,18 +80,13 @@ def place_field(firing_map, **kwargs):
     NotImplementedError
         non-defined peack searching methods
 
-    See also
+    Notes
     --------
     BNT.+analyses.placefieldAdaptive
 
     https://se.mathworks.com/help/images/understanding-morphological-reconstruction.html
 
     Copyright (C) 2018 by Vadim Frolov, (C) 2019 by Simon Ball, Horst Obenhaus
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
     ##########################################################################
     #####                   Part 1: Handle inputs

--- a/opexebo/analysis/populationVectorCorrelation.py
+++ b/opexebo/analysis/populationVectorCorrelation.py
@@ -14,88 +14,80 @@ def population_vector_correlation(stack_0, stack_1, **kwargs):
     Take a single column through the stack (i.e. 1 single bin/location in
     arena, with a firing rate for each cell), from each stack
     
-    In the original MatLab implementation, three output modes were supported:
-    - 1D: (1x numYbins)
-        iterate over i
-            Take a 2D slice from each stack - all cells at all X positions at a
-            single Y position i
-            Reshape from 2D to 1D 
-            Calculate the Pearson correlation coefficient between the two 1D
-            arrays
-            The value of pv_corr[i] is the Pearson correlation coefficient
-            arising from Y position i
-    - 2D (numXbins x numYbins)
-        iterate over i
-            Take a 2D slice from each stack - all cells at all X positions at a
-            single Y position i
-            Calculate the 2D array (numXbins x numYbins) where the [j,k]th
-            value is the Pearson correlation coefficient between all
-            observations at the j'th X location in stack_left and the k'th
-            location in stack_right
-            The i'th row of pv_corr is the DIAGONAL of the correlation matrix
-            i.e. where j==k i.e. the correlation of the the SAME location in
-            each stack for all observations (numCells)
-    - 3D (numXbins x numYbins x iteration(=numYbins))
-        Same as 2D BUT take the whole correlation matrix, not the diagonal
-        i.e. the full [j,k] correlatio between all X locations
+    In the original MatLab implementation, three output modes were supported
+        * 1D: (`numYbins`) - iterate over `i`
+            1) Take a 2D slice from each stack - all cells at all `X` positions at a
+              single `Y` position `i`
+            2) Reshape from 2D to 1D 
+            3) Calculate the Pearson correlation coefficient between the two 1D
+              arrays
+            4) The value of `pv_corr_1d[i]` is the Pearson correlation coefficient
+              arising from `Y` position `i`
+        * 2D (`numXbins` x `numYbins`) - iterate over `i`
+            1) Take a 2D slice from each stack - all cells at all `X` positions at a
+              single `Y` position `i`
+            2) Calculate the 2D array (`numXbins` x `numYbins`) where the `[j,k]`th
+              value is the Pearson correlation coefficient between all
+              observations at the `j`'th `X` location in `stack_left` and the `k`'th
+              location in `stack_right`
+            3) The `i`'th row of `pv_corr_2d` is the DIAGONAL of the correlation matrix
+              i.e. where `j==k` i.e. the correlation of the the SAME location in
+              each stack for all observations (`numCells`)
+        * 3D (`numXbins` x `numYbins` x iteration(=`numYbins`))
+            Same as 2D BUT take the whole correlation matrix, not the diagonal
+            i.e. the full [j,k] correlatio between all X locations
     
     A note on correlation in Numpy vs Matlab
-        Matlab's `corr(a, b)` function returns the correlation of ab
-        Numpy's `corrcoef` function returns the normalised covariance matrix,
-        which is:
-                aa  ab
-                ba  aa
-        The normalised covariance matrix *should* be hermitian, but due to
-        floating point accuracy, this is not actually guaranteed
-        the MatLab function can be reproduced by taking either [0, 1] or [1,0]
-        of the normalised covariance matrix. 
     
-        If `a`, `b` are 2D matricies, then they should have shape
-            (num_variables, num_observations)
-        In the case of this function, where the iterator is over the Y values
-        of the rate map, that means:
-            (x_bins, num_cells)
-            
+    Matlab's `corr(a, b)` function returns the correlation of ab
+    Numpy's `corrcoef` function returns the normalised covariance matrix,
+    which is:
+            aa  ab
+            ba  aa
+    The normalised covariance matrix *should* be hermitian, but due to
+    floating point accuracy, this is not actually guaranteed
+    the MatLab function can be reproduced by taking either [0, 1] or [1,0]
+    of the normalised covariance matrix. 
+
+    If `a`, `b` are 2D matricies, then they should have shape `(num_variables, num_observations)`
+    In the case of this function, where the iterator is over the `Y` values
+    of the rate map, that means: `(x_bins, num_cells)`
 
     Parameters
     ----------
-    stack_0 : 3D array -or- list of 2D arrays
-    stack_1 : 3D array -or- list of 2D arrays
-        stack_x[i] should return the i'th ratemap. This corresponds to a 
+    stack_0: 3D array -or- list of 2D arrays
+    stack_1: 3D array -or- list of 2D arrays
+        `stack_x[i]` should return the `i`'th ratemap. This corresponds to a 
         constructor like:
-            np.zeros(num_layers, y_bins, x_bins)
+            `np.zeros(num_layers, y_bins, x_bins)`
+            
         Alternatively, a list or tuple of 2D arrays may be supplied:
-            stack_x = (ratemap_0, ratemap_1, ratemap_2, ...)
-    row_major : bool
-        Direction of iteration. If True, then each row is iterated over in turn
+            `stack_x` = (`ratemap_0`, `ratemap_1`, `ratemap_2`, ...)
+    row_major: bool
+        Direction of iteration. If `True`, then each row is iterated over in turn
         and correlation is calculated per row. 
-        If false, then each column is iterated over in turn, and correlation is 
+        If `False`, then each column is iterated over in turn, and correlation is 
         calculated per column. 
         Default True (same behavior as in BNT)
-            
 
     Returns
     -------
     (p1, p2, p3)
-    p1 : np.ndarray (1D, iterator x 1)
+    p1: np.ndarray (1D, iterator x 1)
         Array of Pearson correlation coefficients. i'th value is given by the 
         correlation of the i'th flattened slice of stack_0 to the i'th
         flattened slice  of stack_1
-    p2 : np.ndarray (2D, iterator x non-iterator)
-        
-        
-        
+    p2: np.ndarray (2D, iterator x non-iterator)
+        i'th row is the diagonal of the correlation matrix, i.e. the correlation
+        of the same location (location i) in each stack, i.e. where j==k
+    p3: np.ndarray(3D, iterator x non-iterator x non-iterator)
+        i'th array is the entire correlation matrix, rather than just the diagonal
 
-    See Also
+    Notes
     --------
     BNT.+analyses.populationVectorCorrelation
 
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     """
     debug = kwargs.get("debug", False)
     row_major = kwargs.get("row_major", True)

--- a/opexebo/analysis/rateMap.py
+++ b/opexebo/analysis/rateMap.py
@@ -26,34 +26,31 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         Nx3 or Nx4 array of spikes tracking: [t, speed, x] or [t, speed, x, y].
         Speeds are used for the same purpose as in Spatialoccupancy - spikes
         occurring with an instaneous speed below the threshold are discarded
-    bin_width: float
-        Bin size in cm. Bins are always assumed square default 2.5 cm. One
-        of `bin_width`, `bin_number`, `bin_edges` must be provided
-    bin_number: int or tuple of int
-        Number of bins. If a tuple is provided, then (x, y). Either square
-        or rectangular bins are supported. One of `bin_width`, `bin_number`,
-        `bin_edges` must be provided
-    bin_edges: array-like
-        Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`. One
-        of `bin_width`, `bin_number`, `bin_edges` must be provided
     speed_cutoff: float
-        Timestamps with instantaneous speed beneath this value are ignored.
-        Default 0
-    arena_size: float or tuple of floats
-        Dimensions of arena (in cm)
-        For a linear track, length
-        For a circular arena, diameter
-        For a square arena, length or (length, length)
-        For a non-square rectangle, (length1, length2)
-        In this function, a circle and a square are treated identically.
+        Timestamps with instantaneous speed beneath this value are ignored. Default 0
+    bin_width: float
+        Bin size in cm. Default 2.5cm. If bin_width is supplied, `limit` must
+        also be supplied. One of `bin_width`, `bin_number`, `bin_edges` must be
+        provided
+    bin_number: int or tuple of int
+        Number of bins. If provided as a tuple, then `(x_bins, y_bins)`. One
+        of `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_edges: array-like
+        Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
+        One of `bin_width`, `bin_number`, `bin_edges` must be provided
     limits: tuple or np.ndarray
-        (`x_min`, `x_max`) or (`x_min`, `x_max`, `y_min`, `y_max`)
+        (x_min, x_max) or (x_min, x_max, y_min, y_max)
         Provide concrete limits to the range over which the histogram searches
         Any observations outside these limits are discarded
         If no limits are provided, then use np.nanmin(data), np.nanmax(data)
         to generate default limits.
         As is standard in python, acceptable values include the lower bound
         and exclude the upper bound
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
 
     Returns
     -------
@@ -61,12 +58,10 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         2D array, masked at locations of very low occupancy (t<1ms).
         Each cell gives the rate of neuron firing at that location.
 
-    Raises
-    ------
-    ValueError
-        If input values do not match expectations
-    KeyError
-        Absence of arena information
+    See Also
+    --------
+    opexebo.general.accumulate_spatial
+    opexebo.general.bin_width_to_bin_number
 
     Notes
     --------

--- a/opexebo/analysis/rateMap.py
+++ b/opexebo/analysis/rateMap.py
@@ -1,4 +1,4 @@
-"""Provides a function for calculating a Rate map from an 
+"""Provides a function for calculating a Rate map from an
 Occupancy Map and positioned Spike Times"""
 
 import numpy as np
@@ -9,59 +9,58 @@ import opexebo.defaults as default
 
 def rate_map(occupancy_map, spikes_tracking, **kwargs):
     ''' Calculate the spatially correlated firing rate map
-    
+
     The rate map is calculated by the number of spikes in a bin divided by the
-    time the animal spent in that bin. Bins in which the animal spent no or 
+    time the animal spent in that bin. Bins in which the animal spent no or
     very little time are masked such that the value is available for but
     typically excluded from future analyses.
-    
-    The provided arena_size and bin_width **must* provide a number of bins such 
-    that the spike map has the same dimensions as the occupancy map. 
-    
+
+    The provided arena_size and bin_width **must* provide a number of bins such
+    that the spike map has the same dimensions as the occupancy map.
+
     Parameters
     ----------
-    occupancy_map : np.ndarray or np.ma.MaskedArray
+    occupancy_map: np.ndarray or np.ma.MaskedArray
         Nx1 or Nx2 array of time spent by animal in each bin, with time in bins
-    spikes : np.ndarray
+    spikes: np.ndarray
         Nx3 or Nx4 array of spikes tracking: [t, speed, x] or [t, speed, x, y].
         Speeds are used for the same purpose as in Spatialoccupancy - spikes
         occurring with an instaneous speed below the threshold are discarded
-    **kwargs
-        bin_width : float. 
-            Bin size in cm. Bins are always assumed square default 2.5 cm. One
-            of `bin_width`, `bin_number`, `bin_edges` must be provided
-        bin_number: int or tuple of int
-            Number of bins. If a tuple is provided, then (x, y). Either square
-            or rectangular bins are supported. One of `bin_width`, `bin_number`,
-            `bin_edges` must be provided
-        bin_edges: array-like
-            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`. One
-            of `bin_width`, `bin_number`, `bin_edges` must be provided
-        speed_cutoff    : float. 
-            Timestamps with instantaneous speed beneath this value are ignored. 
-            Default 0
-        arena_size : float or tuple of floats. 
-            Dimensions of arena (in cm)
-            For a linear track, length
-            For a circular arena, diameter
-            For a square arena, length or (length, length)
-            For a non-square rectangle, (length1, length2)
-            In this function, a circle and a square are treated identically.
-        limits : tuple or np.ndarray
-            (x_min, x_max) or (x_min, x_max, y_min, y_max)
-            Provide concrete limits to the range over which the histogram searches
-            Any observations outside these limits are discarded
-            If no limits are provided, then use np.nanmin(data), np.nanmax(data)
-            to generate default limits. 
-            As is standard in python, acceptable values include the lower bound
-            and exclude the upper bound
+    bin_width: float
+        Bin size in cm. Bins are always assumed square default 2.5 cm. One
+        of `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_number: int or tuple of int
+        Number of bins. If a tuple is provided, then (x, y). Either square
+        or rectangular bins are supported. One of `bin_width`, `bin_number`,
+        `bin_edges` must be provided
+    bin_edges: array-like
+        Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`. One
+        of `bin_width`, `bin_number`, `bin_edges` must be provided
+    speed_cutoff: float
+        Timestamps with instantaneous speed beneath this value are ignored.
+        Default 0
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+        For a linear track, length
+        For a circular arena, diameter
+        For a square arena, length or (length, length)
+        For a non-square rectangle, (length1, length2)
+        In this function, a circle and a square are treated identically.
+    limits: tuple or np.ndarray
+        (`x_min`, `x_max`) or (`x_min`, `x_max`, `y_min`, `y_max`)
+        Provide concrete limits to the range over which the histogram searches
+        Any observations outside these limits are discarded
+        If no limits are provided, then use np.nanmin(data), np.nanmax(data)
+        to generate default limits.
+        As is standard in python, acceptable values include the lower bound
+        and exclude the upper bound
 
     Returns
     -------
-    rmap : np.ma.MaskedArray
+    rmap: np.ma.MaskedArray
         2D array, masked at locations of very low occupancy (t<1ms).
         Each cell gives the rate of neuron firing at that location.
-    
+
     Raises
     ------
     ValueError
@@ -69,40 +68,41 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
     KeyError
         Absence of arena information
 
-    See also
+    Notes
     --------
     BNT.+analyses.map()
+
+    Copyright (C) 2019 by Simon Ball
     '''
 
     # Check correct inputs
-    if type(occupancy_map) not in (np.ndarray, np.ma.MaskedArray) :
+    if not isinstance(occupancy_map, (np.ndarray, np.ma.MaskedArray)):
         raise ValueError("Occupancy Map not provided in usable format. Please"\
             " provide either a Numpy ndarray or Numpy MaskedArray. You"\
             f" provided {type(occupancy_map)}.")
-    if type(spikes_tracking) not in (np.ndarray, np.ma.MaskedArray) :
+    if not isinstance(spikes_tracking, (np.ndarray, np.ma.MaskedArray)):
         raise ValueError("spikes not provided in usable format. Please"\
             " provide either a Numpy ndarray or Numpy MaskedArray. You"\
             f" provided {type(spikes_tracking)}.")
-    
+
     dims_p = occupancy_map.ndim
-    dims_s, num_samples_s = spikes_tracking.shape
+    dims_s, _ = spikes_tracking.shape
     if dims_s-2 != dims_p:
         raise ValueError("Spikes must have the same number of spatial"\
             " dimensions as positions ([t, s, x] or [t, s, x, y]). You have provided"\
             f" {dims_s} columns of spikes, and {dims_p} columns of positions")
-    
-    if "arena_size" not in kwargs:
-        raise KeyError("No arena dimensions provided. Please provide the\
-                    dimensions of the arena by using keyword 'arena_size'.")
 
-    if type(occupancy_map) == np.ndarray:
+    if "arena_size" not in kwargs:
+        raise KeyError("No arena dimensions provided. Please provide the"\
+                    " dimensions of the arena by using keyword 'arena_size'.")
+
+    if isinstance(occupancy_map, np.ndarray):
         occupancy_map = np.ma.MaskedArray(occupancy_map)
 
     speed_cutoff = kwargs.get("speed_cutoff", default.speed_cutoff)
 
-    times = spikes_tracking[0, :] # never actually used
     speeds = spikes_tracking[1, :]
-    good_speeds = speeds>speed_cutoff
+    good_speeds = speeds > speed_cutoff
     if dims_s == 3:
         spikes = spikes_tracking[2, :][good_speeds]
     elif dims_s == 4:
@@ -111,16 +111,14 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         spikes = np.array((spikes_x, spikes_y))
 
     # Histogram of spike positions
-    spike_map, edges = opexebo.general.accumulate_spatial(spikes, **kwargs)
+    spike_map, _ = opexebo.general.accumulate_spatial(spikes, **kwargs)
 
     if spike_map.shape != occupancy_map.shape:
         raise ValueError("Rate Map and Occupancy Map must have the same"\
-                    " dimensions. Provided: %s, %s" % (spike_map.shape, 
-                                                    occupancy_map.shape))
+                         f" dimensions. Provided: {spike_map.shape},"\
+                         f" {occupancy_map.shape}")
     # Convert to rate map
-    rmap = spike_map / (occupancy_map + np.spacing(1)) 
+    rmap = spike_map / (occupancy_map + np.spacing(1))
     # spacing adds floating point precision to avoid DivideByZero errors
     # These should be impossible due to masking, but included nevertheless
     return rmap
-    
-    

--- a/opexebo/analysis/rateMap.py
+++ b/opexebo/analysis/rateMap.py
@@ -121,7 +121,6 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
     rmap = spike_map / (occupancy_map + np.spacing(1)) 
     # spacing adds floating point precision to avoid DivideByZero errors
     # These should be impossible due to masking, but included nevertheless
-
     return rmap
     
     

--- a/opexebo/analysis/rateMap.py
+++ b/opexebo/analysis/rateMap.py
@@ -7,7 +7,7 @@ import opexebo
 import opexebo.defaults as default
 
 
-def rate_map(occupancy_map, spikes_tracking, **kwargs):
+def rate_map(occupancy_map, spikes_tracking, arena_size, **kwargs):
     ''' Calculate the spatially correlated firing rate map
 
     The rate map is calculated by the number of spikes in a bin divided by the
@@ -26,6 +26,11 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         Nx3 or Nx4 array of spikes tracking: [t, speed, x] or [t, speed, x, y].
         Speeds are used for the same purpose as in Spatialoccupancy - spikes
         occurring with an instaneous speed below the threshold are discarded
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
     speed_cutoff: float
         Timestamps with instantaneous speed beneath this value are ignored. Default 0
     bin_width: float
@@ -46,11 +51,6 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         to generate default limits.
         As is standard in python, acceptable values include the lower bound
         and exclude the upper bound
-    arena_size: float or tuple of floats
-        Dimensions of arena (in cm)
-            * For a linear track, length
-            * For a circular arena, diameter
-            * For a rectangular arena, length or (length, length)
 
     Returns
     -------
@@ -87,10 +87,6 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
             " dimensions as positions ([t, s, x] or [t, s, x, y]). You have provided"\
             f" {dims_s} columns of spikes, and {dims_p} columns of positions")
 
-    if "arena_size" not in kwargs:
-        raise KeyError("No arena dimensions provided. Please provide the"\
-                    " dimensions of the arena by using keyword 'arena_size'.")
-
     if isinstance(occupancy_map, np.ndarray):
         occupancy_map = np.ma.MaskedArray(occupancy_map)
 
@@ -106,7 +102,7 @@ def rate_map(occupancy_map, spikes_tracking, **kwargs):
         spikes = np.array((spikes_x, spikes_y))
 
     # Histogram of spike positions
-    spike_map, _ = opexebo.general.accumulate_spatial(spikes, **kwargs)
+    spike_map, _ = opexebo.general.accumulate_spatial(spikes, arena_size, **kwargs)
 
     if spike_map.shape != occupancy_map.shape:
         raise ValueError("Rate Map and Occupancy Map must have the same"\

--- a/opexebo/analysis/rateMapCoherence.py
+++ b/opexebo/analysis/rateMapCoherence.py
@@ -8,46 +8,42 @@ from astropy.convolution import convolve
 def rate_map_coherence(rate_map_raw):
     '''
     Calculate coherence of a rate map
-    
+
     Coherence is calculated based on RU Muller, JL Kubie "The firing of hippocampal place
     cells predicts the future position of freely moving rats", Journal of Neuroscience, 1 December 1989,
     9(12):4101-4110. The paper doesn't provide information about how to deal with border values
     which do not have 8 well-defined neighbours. This function uses zero-padding technique.
-    
+
     Parameters
     ----------
-    rate_map_raw       : np.ma.MaskedArray
+    rate_map_raw: np.ma.MaskedArray
         Non-smoothed rate map: n x m array where cell value is the firing rate,
         masked at locations with low occupancy
-    
+
     Returns
     -------
-    coherence           : float
+    coherence: float
         see relevant literature (above)
-    See also
-    --------
+
+    Notes
+    -----
     BNT.+analyses.coherence(map)
         
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
-    
+
     kernel = np.array([[0.125, 0.125, 0.125],
                       [0.125, 0,     0.125],
                       [0.125, 0.125, 0.125]])
-    
+
     avg_map = convolve(rate_map_raw, kernel, 'fill', fill_value=0)
     avg_map = avg_map.ravel()
     avg_map = np.nan_to_num(avg_map)
-    
+
     rmap = np.copy(rate_map_raw)
     rmap = rmap.ravel()
     rmap = np.nan_to_num(rmap)
-    
+
     coherence = np.corrcoef(avg_map, rmap)[0,1]
-    
+
     return coherence

--- a/opexebo/analysis/rateMapStats.py
+++ b/opexebo/analysis/rateMapStats.py
@@ -5,61 +5,57 @@ import numpy as np
 
 def rate_map_stats(rate_map, time_map, debug=False):
     '''
-    Calculate statistics of a rate map that depend on probability distribution 
+    Calculate statistics of a rate map that depend on probability distribution
     function (PDF)
     
-    Calculates information, sparsity and selectivity of a rate map. Calculations 
+    Calculates information, sparsity and selectivity of a rate map. Calculations
     are done according to 1993 Skaggs et al. "An Information-Theoretic Approach
     to Deciphering the Hippocampal Code" paper. Another source of information is
-    1996 Skaggs et al. paper called "Theta phase precession in hippocampal 
+    1996 Skaggs et al. paper called "Theta phase precession in hippocampal
     neuronal populations and the compression of temporal sequences".
-    
-    Coherence is calculated based on RU Muller, JL Kubie "The firing of 
+
+    Coherence is calculated based on RU Muller, JL Kubie "The firing of
     hippocampal place cells predicts the future position of freely moving rats",
     Journal of Neuroscience, 1 December 1989, 9(12):4101-4110. The paper doesn't
     provide information about how to deal with border values which do not have
     8 well-defined neighbours. This function uses zero-padding technique.
-    
+
     Parameters
     ----------
-    rate_map        : np.ma.MaskedArray
-        Smoothed rate map: n x m array where cell value is the firing rate, 
+    rate_map: np.ma.MaskedArray
+        Smoothed rate map: n x m array where cell value is the firing rate,
         masked at locations with low occupancy
-        
-    time_map   : np.ma.MaskedArray
+
+    time_map: np.ma.MaskedArray
         time map: n x m array where the cell value is the time the animal spent
         in each cell, masked at locations with low occupancy
         Already smoothed
-    
+
     Returns
     -------
-    rms : dict
-        spatial_information_rate    : float
+    rms: dict
+        spatial_information_rate: float
             information rate [bits/sec]
-        spatial_information_content : float
+        spatial_information_content: float
             spatial information content [bits/spike]
-        sparsity            : float
+        sparsity: float
             see relevant literature (above)
-        selectivity         : float
+        selectivity: float
             see relevant literature (above)
-        peak_rate : float
+        peak_rate: float
             peak firing rate of smoothed map [Hz]
-        mean_rate : float
+        mean_rate: float
             mean firing rate of smoothed map [Hz]
 
-    See also
-    --------
+    Notes
+    -----
     BNT.+analyses.mapStatsPDF(map)
+    
     BNT.+analyses.coherence(map)
-        
-    Copyright (C) 2019 by Simon Ball
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+    Copyright (C) 2019 by Simon Ball
     '''
-     
+
     if type(rate_map) != np.ma.MaskedArray:
         rate_map = np.ma.masked_invalid(rate_map, copy=True)
     if type(time_map) != np.ma.MaskedArray:
@@ -68,7 +64,7 @@ def rate_map_stats(rate_map, time_map, debug=False):
     duration = np.ma.sum(time_map)
     position_PDF = time_map / (duration + np.spacing(1)) 
     # Probability distribution of where the animal spent its time. 
-    
+
     if debug:
         print("Duration = %ds" % duration)
         print("Masked locations: %d" % np.sum(rate_map.mask))
@@ -86,25 +82,24 @@ def rate_map_stats(rate_map, time_map, debug=False):
     else:
         rmap_mean = np.nanmean(rate_map)
         rmap_peak = np.nanmax(rate_map)
-    
+
     mean_rate = np.ma.sum( rate_map * position_PDF )
     mean_rate_sq = np.ma.sum( np.ma.power(rate_map, 2) * position_PDF )
-    
+
     max_rate = np.max(rate_map)
-    
+
     if debug:
         print("mean rate: %.2fHz" % mean_rate)
         print("mean rate squared: %.2fHz^2" % mean_rate_sq)
         print("max rate: %.2fHz" % max_rate)
-        
 
-    
+
     if mean_rate_sq != 0:
         sparsity = mean_rate * mean_rate / mean_rate_sq
-    
+
     if mean_rate != 0:
         selectivity = max_rate / mean_rate
-        
+
         log_argument = rate_map / mean_rate
         log_argument[log_argument < 1] = 1
         if debug:
@@ -112,16 +107,9 @@ def rate_map_stats(rate_map, time_map, debug=False):
             #print("log argument: %.4f" % log_argument)
         inf_rate = np.ma.sum(position_PDF * rate_map * np.ma.log2(log_argument))
         inf_content = inf_rate / mean_rate
-        
-    
-        
+
+
+
     return {"spatial_information_rate":inf_rate, "spatial_information_content":inf_content,
             "sparsity":sparsity, "selectivity":selectivity, "peak_rate":rmap_peak,
             "mean_rate":rmap_mean}
-
-    
-    
-    
-    
-    
-    

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -41,8 +41,22 @@ def spatial_occupancy(time, position, speed, **kwargs):
             For a square arena, length or (x_length, y_length)
             For a non-square rectangle, (x_length, y_length)
             In this function, a circle and a square are treated identically.
-        bin_width       : float. 
-            Bin size (in cm). Bins are always assumed square default 2.5 cm.
+       bin_width : float. 
+            Bin size in cm. Bins are always assumed square default 2.5 cm. If 
+            bin_width is supplied, `limit` must also be supplied. One of 
+            `bin_width`, `bin_number`, `bin_edges` must be provided
+        bin_number: int or tuple of int
+            Number of bins. If provided as a tuple, then (x_bins, y_bins). One
+            of `bin_width`, `bin_number`, `bin_edges` must be provided
+        bin_edges: array-like
+            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
+            One of `bin_width`, `bin_number`, `bin_edges` must be provided
+            Dimensions of arena (in cm)
+            For a linear track, length
+            For a circular arena, diameter
+            For a square arena, length or (length, length)
+            For a non-square rectangle, (length1, length2)
+            In this function, a circle and a square are treated identically.
         speed_cutoff    : float. 
             Timestamps with instantaneous speed beneath this value are ignored. 
             Default 0
@@ -144,14 +158,10 @@ def spatial_occupancy(time, position, speed, **kwargs):
         coverage = np.count_nonzero(occupancy_map) / occupancy_map.size
     elif shape.lower() in default.shapes_circle:
         if type(arena_size) in (float, int):
-            radius = arena_size / 2
+            diameter = arena_size
         elif type(arena_size) in (tuple, list, np.ndarray):
-            radius = arena_size[0]/2
-        x_centres = bin_edges[0][:-1] + (bin_width / 2)
-        y_centres = bin_edges[1][:-1] + (bin_width / 2)
-        X, Y = np.meshgrid(x_centres, y_centres)
-        distance_map = np.sqrt(np.power(X,2) + np.power(Y,2))
-        in_field = distance_map<=radius
+            diameter = arena_size[0]
+        in_field, _ = opexebo.general.circular_mask(bin_edges, diameter)
         
         coverage = min(1.0, np.count_nonzero(occupancy_map) / (np.sum(in_field)))
             # Due to the thresholding, coverage might be calculated to be  > 1

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -110,19 +110,14 @@ def spatial_occupancy(time, position, speed, **kwargs):
     
     # Handle NaN positions by converting to a Masked Array
     position = np.ma.masked_invalid(position)
-    
-    
+
     speed_cutoff = kwargs.get("speed_cutoff", default.speed_cutoff)
     debug = kwargs.get("debug", False)
-    
 
-
-    
     if debug:
         print("Number of time stamps: %d" % len(time))
         print("Maximum time stamp value: %.2f" % time[-1])
         print("Time stamp delta: %f" % np.min(np.diff(time)))
-   
 
     good = np.ma.greater_equal(speed, speed_cutoff)
     x = position[0,:][good]
@@ -139,8 +134,7 @@ def spatial_occupancy(time, position, speed, **kwargs):
     occupancy_map_time = occupancy_map * frame_duration
     
     if debug:
-        print("Time length included in histogram: %.2f (%.3f)" % (np.sum(occupancy_map_time), np.sum(occupancy_map_time)/time[-1]) )
-    
+        print("Time length included in histogram: %.2f (%.3f)" % (np.sum(occupancy_map_time), np.sum(occupancy_map_time)/time[-1]))
 
     masked_map = np.ma.masked_where(occupancy_map < 0.001, occupancy_map_time)
     
@@ -151,7 +145,6 @@ def spatial_occupancy(time, position, speed, **kwargs):
     # accessible
     
     arena_size = kwargs.get("arena_size")
-    bin_width = kwargs.get("bin_width", default.bin_width)
     shape = kwargs.get("arena_shape", default.shape)
     
     if shape.lower() in default.shapes_square:
@@ -162,8 +155,8 @@ def spatial_occupancy(time, position, speed, **kwargs):
         elif type(arena_size) in (tuple, list, np.ndarray):
             diameter = arena_size[0]
         in_field, _ = opexebo.general.circular_mask(bin_edges, diameter)
-        
-        coverage = min(1.0, np.count_nonzero(occupancy_map) / (np.sum(in_field)))
+        coverage = np.count_nonzero(occupancy_map) / (np.sum(in_field))
+        coverage = min(1.0, coverage)
             # Due to the thresholding, coverage might be calculated to be  > 1
             # In this case, cut off to a maximum value of 1.
     elif shape.lower() in default.shapes_linear:
@@ -171,7 +164,7 @@ def spatial_occupancy(time, position, speed, **kwargs):
                                   " support linear arenas")
     else:
         raise NotImplementedError(f"Arena shape '{shape}' not understood")
-    
+
     return masked_map, coverage, bin_edges
     
     

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -7,7 +7,7 @@ from opexebo import defaults as default
 
 
 
-def spatial_occupancy(time, position, speed, **kwargs):
+def spatial_occupancy(time, position, speed, arena_size, **kwargs):
     '''
     Generate an occpuancy map: how much time the animal spent in each location
     in the arena.
@@ -26,6 +26,11 @@ def spatial_occupancy(time, position, speed, **kwargs):
         that `position[0]` corresponds to all `x`; and `position[1]` to all `y`
     speed: np.ndarray
         1d array of speeds at timestamps
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
     speed_cutoff: float
         Timestamps with instantaneous speed beneath this value are ignored. Default 0
     arena_shape: {"square", "rect", "circle", "line"}
@@ -49,11 +54,6 @@ def spatial_occupancy(time, position, speed, **kwargs):
         to generate default limits.
         As is standard in python, acceptable values include the lower bound
         and exclude the upper bound
-    arena_size: float or tuple of floats
-        Dimensions of arena (in cm)
-            * For a linear track, length
-            * For a circular arena, diameter
-            * For a rectangular arena, length or (length, length)
     debug: bool, optional
         If `true`, print out debugging information throughout the function.
         Default `False`
@@ -89,9 +89,6 @@ def spatial_occupancy(time, position, speed, **kwargs):
         raise ValueError("Speed array has the wrong number of columns")
     if speed.size != num_samples:
         raise ValueError("Speed array does not have the same number of samples as Positions")
-    if "arena_size" not in kwargs:
-        raise KeyError("Arena dimensions not provided. Please provide dimensions"\
-                       " using keyword 'arena_size'.")
 
     # Handle NaN positions by converting to a Masked Array
     position = np.ma.masked_invalid(position)
@@ -108,7 +105,7 @@ def spatial_occupancy(time, position, speed, **kwargs):
     pos = np.array([position[0, :][good],
                     position[1, :][good]])
 
-    occupancy_map, bin_edges = opexebo.general.accumulate_spatial(pos, **kwargs)
+    occupancy_map, bin_edges = opexebo.general.accumulate_spatial(pos, arena_size, **kwargs)
     if debug:
         print(f"Frames included in histogram: {np.sum(occupancy_map)}"\
               f" ({np.sum(occupancy_map)/len(time):3})")
@@ -130,7 +127,7 @@ def spatial_occupancy(time, position, speed, **kwargs):
     # Does not take account of a circular arena, where not all locations are
     # accessible
 
-    arena_size = kwargs.get("arena_size")
+#    arena_size = kwargs.get("arena_size")
     shape = kwargs.get("arena_shape", default.shape)
 
     if shape.lower() in default.shapes_square:

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -10,104 +10,87 @@ from opexebo import defaults as default
 def spatial_occupancy(time, position, speed, **kwargs):
     '''
     Generate an occpuancy map: how much time the animal spent in each location
-    in the arena.    
-    
+    in the arena.
+
     NOTES: This assumes that the positions have already been aligned and curated
-    to remove NaNs. This is based on the expectation that it will primarily be 
-    used within the DataJoint framework, where the curation takes place at a 
+    to remove NaNs. This is based on the expectation that it will primarily be
+    used within the DataJoint framework, where the curation takes place at a
     much earlier stage.
-    
+
     Parameters
     ----------
-    time       : ndarray
-        [t] timestamps of position and speed data
-    position   : ndarray. 
-        [x, y] or [x]. [0,:] -> xThis matches array creation 
-        with positions=np.array([x, y])
-    speed       : ndarray. 
-        [s]
-    
-    kwargs
-        arena_shape : str
-            accepts: ("square", "rectangle", "rectangular", "rect", "s", "r")
-                    ("circ", "circular", "circle", "c")
-                    ("linear", "line", "l")
-            Rectangular and square are equivalent. Elliptical or n!=4 polygons
-            not currently supported. Defaults to Rectangular
-        arena_size      : float or tuple of floats. 
-            Dimensions of arena (in cm)
-            For a linear track, length
-            For a circular arena, diameter
-            For a square arena, length or (x_length, y_length)
-            For a non-square rectangle, (x_length, y_length)
-            In this function, a circle and a square are treated identically.
-       bin_width : float. 
-            Bin size in cm. Bins are always assumed square default 2.5 cm. If 
-            bin_width is supplied, `limit` must also be supplied. One of 
-            `bin_width`, `bin_number`, `bin_edges` must be provided
-        bin_number: int or tuple of int
-            Number of bins. If provided as a tuple, then (x_bins, y_bins). One
-            of `bin_width`, `bin_number`, `bin_edges` must be provided
-        bin_edges: array-like
-            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
-            One of `bin_width`, `bin_number`, `bin_edges` must be provided
-            Dimensions of arena (in cm)
-            For a linear track, length
-            For a circular arena, diameter
-            For a square arena, length or (length, length)
-            For a non-square rectangle, (length1, length2)
-            In this function, a circle and a square are treated identically.
-        speed_cutoff    : float. 
-            Timestamps with instantaneous speed beneath this value are ignored. 
-            Default 0
-        limits : tuple or np.ndarray
-            (x_min, x_max) or (x_min, x_max, y_min, y_max)
-            Provide concrete limits to the range over which the histogram searches
-            Any observations outside these limits are discarded
-            If no limits are provided, then use np.nanmin(data), np.nanmax(data)
-            to generate default limits. 
-            As is standard in python, acceptable values include the lower bound
-            and exclude the upper bound
-        debug           : bool
-            If true, print out debugging information throughout the function.
-            Default False
-    
+    time: np.ndarray
+        timestamps of position and speed data
+    position: np.ndarray (x, [y])
+        1d or 2d array of positions at timestamps. If 2d, then row major, such
+        that `position[0]` corresponds to all `x`; and `position[1]` to all `y`
+    speed: np.ndarray
+        1d array of speeds at timestamps
+    arena_shape: {"square", "rect", "circle", "line"}
+        Rectangular and square are equivalent. Elliptical or n!=4 polygons
+        not currently supported. Defaults to Rectangular
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+        For a linear track, length
+        For a circular arena, diameter
+        For a square arena, length or (x_length, y_length)
+        For a non-square rectangle, (x_length, y_length)
+        In this function, a circle and a square are treated identically.
+    bin_width: float, optional
+        Bin size in cm. Bins are always assumed square, default 2.5 cm. If
+        `bin_width` is supplied, `limit` must also be supplied. One of
+        `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_number: int or tuple of int, optional
+        Number of bins. If provided as a tuple, then (`x_bins`, `y_bins`). One
+        of `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_edges: array-like, optional
+        Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
+        One of `bin_width`, `bin_number`, `bin_edges` must be provided
+    speed_cutoff: float, optional
+        Timestamps with instantaneous speed beneath this value are ignored.
+        Default 0
+    limits : tuple or ndarray, optional
+        (`x_min`, `x_max`) or (`x_min`, `x_max`, `y_min`, `y_max`)
+        Provide concrete limits to the range over which the histogram searches
+        Any observations outside these limits are discarded
+        If no limits are provided, then use `np.nanmin(data)`, `np.nanmax(data)`
+        to generate default limits.
+        As is standard in python, acceptable values include the lower bound
+        and exclude the upper bound
+    debug: bool, optional
+        If `true`, print out debugging information throughout the function.
+        Default `False`
+
     Returns
     -------
-    masked_map : np.ma.MaskedArray
+    masked_map: np.ma.MaskedArray
         Unsmoothed map of time the animal spent in each bin.
-        Bins which the animal never visited are masked (i.e. the mask value is 
-        True at these locations)
-    coverage : float
+        Bins which the animal never visited are masked (i.e. the mask value is
+        `True` at these locations)
+    coverage: float
         Fraction of the bins that the animal visited. In range [0, 1]
-    bin_edges : list-like
+    bin_edges: ndarray or tuple of ndarray
         x, or (x, y), where x, y are 1d np.ndarrays
         Here x, y correspond to the output histogram
-    
-    
-    See also
+
+    Notes
     --------
     BNT.+analyses.map
-        
-    Copyright (C) 2019 by Simon Ball
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+    Copyright (C) 2019 by Simon Ball
     '''
-    # Check for correct shapes. 
+    # Check for correct shapes.
     dimensionality, num_samples = position.shape
     if dimensionality not in (1, 2):
         raise ValueError("Positions array has the wrong number of columns (%d)" % dimensionality)
     if speed.ndim != 1:
         raise ValueError("Speed array has the wrong number of columns")
     if speed.size != num_samples:
-        raise ValueError("Speed array does not have the same number of samples as Positions")    
+        raise ValueError("Speed array does not have the same number of samples as Positions")
     if "arena_size" not in kwargs:
-        raise KeyError("Arena dimensions not provided. Please provide dimensions using keyword 'arena_size'.")
-    
-    
+        raise KeyError("Arena dimensions not provided. Please provide dimensions"\
+                       " using keyword 'arena_size'.")
+
     # Handle NaN positions by converting to a Masked Array
     position = np.ma.masked_invalid(position)
 
@@ -120,52 +103,50 @@ def spatial_occupancy(time, position, speed, **kwargs):
         print("Time stamp delta: %f" % np.min(np.diff(time)))
 
     good = np.ma.greater_equal(speed, speed_cutoff)
-    x = position[0,:][good]
-    y = position[1,:][good]
-    pos = np.array([x,y])
-    
+    pos = np.array([position[0, :][good],
+                    position[1, :][good]])
+
     occupancy_map, bin_edges = opexebo.general.accumulate_spatial(pos, **kwargs)
     if debug:
-        print("Frames included in histogram: %d (%.3f)" % (np.sum(occupancy_map), np.sum(occupancy_map)/len(time)) )
+        print(f"Frames included in histogram: {np.sum(occupancy_map)}"\
+              f" ({np.sum(occupancy_map)/len(time):3})")
 
     # So far, times are expressed in units of tracking frames
     # Convert to seconds:
-    frame_duration = np.min(np.diff(time))    
+    frame_duration = np.min(np.diff(time))
     occupancy_map_time = occupancy_map * frame_duration
-    
+
     if debug:
-        print("Time length included in histogram: %.2f (%.3f)" % (np.sum(occupancy_map_time), np.sum(occupancy_map_time)/time[-1]))
+        print(f"Time length included in histogram: {np.sum(occupancy_map_time):2}"\
+              f"({np.sum(occupancy_map_time)/time[-1]:3})")
 
     masked_map = np.ma.masked_where(occupancy_map < 0.001, occupancy_map_time)
-    
+
     # Calculate the fractional coverage based on the mask. The occupancy_map is
     # zero where the animal has not gone, and therefore non-zero where the animal
     # HAS gone. . Coverage is 1.0 when the animal has visited every location
     # Does not take account of a circular arena, where not all locations are
     # accessible
-    
+
     arena_size = kwargs.get("arena_size")
     shape = kwargs.get("arena_shape", default.shape)
-    
+
     if shape.lower() in default.shapes_square:
         coverage = np.count_nonzero(occupancy_map) / occupancy_map.size
     elif shape.lower() in default.shapes_circle:
-        if type(arena_size) in (float, int):
+        if isinstance(arena_size, (float, int)):
             diameter = arena_size
-        elif type(arena_size) in (tuple, list, np.ndarray):
+        elif isinstance(arena_size, (tuple, list, np.ndarray)):
             diameter = arena_size[0]
         in_field, _ = opexebo.general.circular_mask(bin_edges, diameter)
         coverage = np.count_nonzero(occupancy_map) / (np.sum(in_field))
         coverage = min(1.0, coverage)
-            # Due to the thresholding, coverage might be calculated to be  > 1
-            # In this case, cut off to a maximum value of 1.
+        # Due to the thresholding, coverage might be calculated to be  > 1
+        # In this case, cut off to a maximum value of 1.
     elif shape.lower() in default.shapes_linear:
-        raise NotImplementedError("Spatial Occupancy does not currently"
+        raise NotImplementedError("Spatial Occupancy does not currently"\
                                   " support linear arenas")
     else:
         raise NotImplementedError(f"Arena shape '{shape}' not understood")
 
     return masked_map, coverage, bin_edges
-    
-    
-     

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -26,37 +26,34 @@ def spatial_occupancy(time, position, speed, **kwargs):
         that `position[0]` corresponds to all `x`; and `position[1]` to all `y`
     speed: np.ndarray
         1d array of speeds at timestamps
+    speed_cutoff: float
+        Timestamps with instantaneous speed beneath this value are ignored. Default 0
     arena_shape: {"square", "rect", "circle", "line"}
         Rectangular and square are equivalent. Elliptical or n!=4 polygons
         not currently supported. Defaults to Rectangular
-    arena_size: float or tuple of floats
-        Dimensions of arena (in cm)
-        For a linear track, length
-        For a circular arena, diameter
-        For a square arena, length or (x_length, y_length)
-        For a non-square rectangle, (x_length, y_length)
-        In this function, a circle and a square are treated identically.
-    bin_width: float, optional
-        Bin size in cm. Bins are always assumed square, default 2.5 cm. If
-        `bin_width` is supplied, `limit` must also be supplied. One of
-        `bin_width`, `bin_number`, `bin_edges` must be provided
-    bin_number: int or tuple of int, optional
-        Number of bins. If provided as a tuple, then (`x_bins`, `y_bins`). One
+    bin_width: float
+        Bin size in cm. Default 2.5cm. If bin_width is supplied, `limit` must
+        also be supplied. One of `bin_width`, `bin_number`, `bin_edges` must be
+        provided
+    bin_number: int or tuple of int
+        Number of bins. If provided as a tuple, then `(x_bins, y_bins)`. One
         of `bin_width`, `bin_number`, `bin_edges` must be provided
-    bin_edges: array-like, optional
+    bin_edges: array-like
         Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
         One of `bin_width`, `bin_number`, `bin_edges` must be provided
-    speed_cutoff: float, optional
-        Timestamps with instantaneous speed beneath this value are ignored.
-        Default 0
-    limits : tuple or ndarray, optional
-        (`x_min`, `x_max`) or (`x_min`, `x_max`, `y_min`, `y_max`)
+    limits: tuple or np.ndarray
+        (x_min, x_max) or (x_min, x_max, y_min, y_max)
         Provide concrete limits to the range over which the histogram searches
         Any observations outside these limits are discarded
-        If no limits are provided, then use `np.nanmin(data)`, `np.nanmax(data)`
+        If no limits are provided, then use np.nanmin(data), np.nanmax(data)
         to generate default limits.
         As is standard in python, acceptable values include the lower bound
         and exclude the upper bound
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
     debug: bool, optional
         If `true`, print out debugging information throughout the function.
         Default `False`
@@ -72,6 +69,11 @@ def spatial_occupancy(time, position, speed, **kwargs):
     bin_edges: ndarray or tuple of ndarray
         x, or (x, y), where x, y are 1d np.ndarrays
         Here x, y correspond to the output histogram
+
+    See Also
+    --------
+    opexebo.general.accumulate_spatial
+    opexebo.general.bin_width_to_bin_number
 
     Notes
     --------

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -127,7 +127,6 @@ def spatial_occupancy(time, position, speed, arena_size, **kwargs):
     # Does not take account of a circular arena, where not all locations are
     # accessible
 
-#    arena_size = kwargs.get("arena_size")
     shape = kwargs.get("arena_shape", default.shape)
 
     if shape.lower() in default.shapes_square:

--- a/opexebo/analysis/spatialOccupancy.py
+++ b/opexebo/analysis/spatialOccupancy.py
@@ -137,7 +137,7 @@ def spatial_occupancy(time, position, speed, arena_size, **kwargs):
             diameter = arena_size
         elif isinstance(arena_size, (tuple, list, np.ndarray)):
             diameter = arena_size[0]
-        in_field, _ = opexebo.general.circular_mask(bin_edges, diameter)
+        in_field, _, _ = opexebo.general.circular_mask(bin_edges, diameter)
         coverage = np.count_nonzero(occupancy_map) / (np.sum(in_field))
         coverage = min(1.0, coverage)
         # Due to the thresholding, coverage might be calculated to be  > 1

--- a/opexebo/analysis/speedScore.py
+++ b/opexebo/analysis/speedScore.py
@@ -9,8 +9,6 @@ def speed_score(spike_times, tracking_times, tracking_speeds, **kwargs):
     '''
     Calculate Speed score.
 
-    STATUS : EXPERIMENTAL
-
     Speed score is a correlation between cell firing *rate* and animal speed.
     The Python version is based on BNT.+scripts.speedScore. At Edvard's request,
     both the 2015 and 2016 scores are calculated. The primary difference is how
@@ -30,7 +28,7 @@ def speed_score(spike_times, tracking_times, tracking_speeds, **kwargs):
     Summary:
         * The intention is to correlate (spike firing rate) with (animal speed)
         * Convert an N-length array of spike firing times into an M-length array
-        of spike firing rates, where M is the same length as tracking times
+          of spike firing rates, where M is the same length as tracking times
         * Optional: smooth firing rates
         * Optional: smooth speeds
         * Optional: apply a bandpass filter to speeds
@@ -38,48 +36,49 @@ def speed_score(spike_times, tracking_times, tracking_speeds, **kwargs):
 
     Parameters
     ----------
-    spike_times : np.ndarray
+    spike_times: np.ndarray
         N-length array listing the times at which spikes occurred. [s]
 
-    tracking_times : np.ndarray
+    tracking_times: np.ndarray
         M-length array of time stamps of tracking frames
 
-    tracking_speeds : np.ndarray
+    tracking_speeds: np.ndarray
         M-length array of animal speeds at time stamps given in `tracking_times`
 
-    kwargs:
-        bandpass : str
-            Type of bandpass filter applied to animal speeds. Acceptable values
-            are:
-                * "none" - No speed based filtering is applied
-                * "fixed" - a fixed lower and upper speed bound are used, based
-                on keywords "lower_bound_speed", "upper_bound_speed"
-                * "adaptive" - a fixed lower speed bound is used, based on
-                keyword "lower_bound_speed"
-                    An upper speed bound is determined based on keywords
-                    "upper_bound_time" and "speed_bandwidth"
-        lower_bound_speed' : float
-            Speed in [cm/s] used as the lower edge of the speed bandpass filter
-            ("fixed" and "adaptive")
-        lower_bound_speed' : float
-            Speed in [cm/s] used as the upper edge of the speed bandpass filter
-            ("fixed" only)
-        upper_bound_time : float
-            Duration in [s] used for determining the upper edge of the speed
-            bandpass filter ("adaptive" only)
-        speed_bandwidth : float
-            Range of speeds in [cm/s] used for determining the upper edge of the
-            speed bandpass filter ("adaptive" only)
-        sigma: float
-            Standard deviation in [s] of Gaussian smoothing kernel for smoothing
-            both speed and firing rate data.
-        debug : bool
+    Other Parameters
+    ----------------
+    bandpass: str
+        Type of bandpass filter applied to animal speeds. Acceptable values
+        are
+            * `"none"` - No speed based filtering is applied
+            * `"fixed"` - a fixed lower and upper speed bound are used, based
+              on keywords `"lower_bound_speed"`, `"upper_bound_speed"`
+            * `"adaptive"` - a fixed lower speed bound is used, based on
+              keyword `"lower_bound_speed"`. An upper speed bound is determined
+              based on keywords `"upper_bound_time"` and "`speed_bandwidth"`
+        Default `none`
+    lower_bound_speed: float
+        Speed in [cm/s] used as the lower edge of the speed bandpass filter
+        (`"fixed"` and `"adaptive"`). Default 2cm/s
+    upper_bound_speed: float
+        Speed in [cm/s] used as the upper edge of the speed bandpass filter
+        (`"fixed"` only). Default 15cm/s
+    upper_bound_time: float
+        Duration in [s] used for determining the upper edge of the speed
+        bandpass filter (`"adaptive"` only). Default 10s
+    speed_bandwidth: float
+        Range of speeds in [cm/s] used for determining the upper edge of the
+        speed bandpass filter (`"adaptive"` only). Default 2cm/s
+    sigma: float
+        Standard deviation in [s] of Gaussian smoothing kernel for smoothing
+        both speed and firing rate data. Default 0.5s
+    debug: bool
 
     Returns
     -------
-    scores : dict
-        '2015' : float
-        '2016' : float
+    scores: dict
+        2015: float
+        2016: float
             Variations on the speed score. '2015' is based on the code in the paper
             above, but additionally including an upper speed filter
             '2016' is a modification involving a slightly different approach to
@@ -89,16 +88,11 @@ def speed_score(spike_times, tracking_times, tracking_speeds, **kwargs):
         Most useful in the case of the adaptive filter, because there is no
         other way to find out what was actually used.
 
-    See also
-    --------
+    Notes
+    -----
     BNT.+scripts.speedScore
 
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
     # Check that the provided arrays have correct dimensions
     if spike_times.ndim != 1:

--- a/opexebo/analysis/tuningCurve.py
+++ b/opexebo/analysis/tuningCurve.py
@@ -34,7 +34,7 @@ def tuning_curve(angular_occupancy, spike_angles, **kwargs):
         unsmoothed array of firing rate as a function of angle
         Nx1 array
 
-    See also
+    Notes
     --------
     BNT.+analyses.turningcurve
 

--- a/opexebo/analysis/tuningCurveStats.py
+++ b/opexebo/analysis/tuningCurveStats.py
@@ -64,7 +64,7 @@ def tuning_curve_stats(tuning_curve, **kwargs):
         arc_angle_rad : float
             Angle of the arc defined by percentile
 
-    See also
+    Notes
     --------
     BNT.+analyses.tcStatistics
 

--- a/opexebo/errors.py
+++ b/opexebo/errors.py
@@ -1,0 +1,16 @@
+'''
+Exception classes for the Opexebo library
+'''
+
+# ----- Level 1 -----
+class OpexeboError(Exception):
+    '''
+    Base class for exceptions specific to Opexebo
+    '''
+
+
+# ----- Level 2 -----
+class ArgumentError(OpexeboError):
+    '''
+    Incorrect argument given in some way
+    '''

--- a/opexebo/general/__init__.py
+++ b/opexebo/general/__init__.py
@@ -1,9 +1,9 @@
+from opexebo.general.validateKeyword import validatekeyword__arena_size, validate_keyword_arena_shape
 from opexebo.general.normxcorr2_general import normxcorr2_general
 from opexebo.general.smooth import smooth
 from opexebo.general.shuffle import shuffle
 from opexebo.general.fitEllipse import fit_ellipse
 from opexebo.general.upsample import upsample
-from opexebo.general.validateKeyword import validatekeyword__arena_size
 from opexebo.general.binWidth_to_binNumber import bin_width_to_bin_number
 from opexebo.general.circular_mask import circular_mask
 from opexebo.general.accumulateSpatial import accumulate_spatial
@@ -13,6 +13,7 @@ from opexebo.general.spatialCrossCorrelation import spatial_cross_correlation
 
 
 __all__ = ['normxcorr2_general', 'smooth', 'accumulate_spatial', 'shuffle',
-           'validatekeyword__arena_size', 'fit_ellipse', 'peak_search',
+           'validatekeyword__arena_size', 'validate_keyword_arena_shape',
+           'fit_ellipse', 'peak_search',
            'power_spectrum', 'spatial_cross_correlation', 'bin_width_to_bin_number',
            'circular_mask', 'upsample']

--- a/opexebo/general/__init__.py
+++ b/opexebo/general/__init__.py
@@ -4,6 +4,7 @@ from opexebo.general.shuffle import shuffle
 from opexebo.general.fitEllipse import fit_ellipse
 from opexebo.general.validateKeyword import validatekeyword__arena_size
 from opexebo.general.binWidth_to_binNumber import bin_width_to_bin_number
+from opexebo.general.circular_mask import circular_mask
 from opexebo.general.accumulateSpatial import accumulate_spatial
 from opexebo.general.peakSearch import peak_search
 from opexebo.general.powerSpectrum import power_spectrum
@@ -12,4 +13,5 @@ from opexebo.general.spatialCrossCorrelation import spatial_cross_correlation
 
 __all__ = ['normxcorr2_general', 'smooth', 'accumulate_spatial', 'shuffle',
            'validatekeyword__arena_size', 'fit_ellipse', 'peak_search',
-           'power_spectrum', 'spatial_cross_correlation', 'bin_width_to_bin_number']
+           'power_spectrum', 'spatial_cross_correlation', 'bin_width_to_bin_number',
+           'circular_mask']

--- a/opexebo/general/__init__.py
+++ b/opexebo/general/__init__.py
@@ -2,6 +2,7 @@ from opexebo.general.normxcorr2_general import normxcorr2_general
 from opexebo.general.smooth import smooth
 from opexebo.general.shuffle import shuffle
 from opexebo.general.fitEllipse import fit_ellipse
+from opexebo.general.upsample import upsample
 from opexebo.general.validateKeyword import validatekeyword__arena_size
 from opexebo.general.binWidth_to_binNumber import bin_width_to_bin_number
 from opexebo.general.circular_mask import circular_mask
@@ -14,4 +15,4 @@ from opexebo.general.spatialCrossCorrelation import spatial_cross_correlation
 __all__ = ['normxcorr2_general', 'smooth', 'accumulate_spatial', 'shuffle',
            'validatekeyword__arena_size', 'fit_ellipse', 'peak_search',
            'power_spectrum', 'spatial_cross_correlation', 'bin_width_to_bin_number',
-           'circular_mask']
+           'circular_mask', 'upsample']

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -5,7 +5,7 @@ from opexebo.general import validatekeyword__arena_size, bin_width_to_bin_number
 import opexebo.defaults as default
 
 
-def accumulate_spatial(pos, **kwargs):
+def accumulate_spatial(pos, arena_size, **kwargs):
     """
     Given a list of positions, create a histogram of those positions. The
     resulting histogram is typically referred to as a map.
@@ -33,6 +33,11 @@ def accumulate_spatial(pos, **kwargs):
     pos: np.ndarray
         1D or 2D array of positions  in row-major format, i.e. `x` = pos[0],
         `y` = pos[1]. This matches the simplest input creation pos = np.array( [`x`, `y`] )
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
     bin_width: float
         Bin size in cm. Default 2.5cm. If bin_width is supplied, `limit` must
         also be supplied. One of `bin_width`, `bin_number`, `bin_edges` must be
@@ -51,11 +56,6 @@ def accumulate_spatial(pos, **kwargs):
         to generate default limits.
         As is standard in python, acceptable values include the lower bound
         and exclude the upper bound
-    arena_size: float or tuple of floats
-        Dimensions of arena (in cm)
-            * For a linear track, length
-            * For a circular arena, diameter
-            * For a rectangular arena, length or (length, length)
 
     Returns
     -------
@@ -87,7 +87,7 @@ def accumulate_spatial(pos, **kwargs):
 
     # Get kwargs values
     debug = kwargs.get("debug", False)
-    arena_size = kwargs.get("arena_size")
+#    arena_size = kwargs.get("arena_size")
     limits = kwargs.get("limits", None)
     if not isinstance(limits, (tuple, list, np.ndarray, type(None))):
         raise ValueError("You must provide an array-like 'limits' value, e.g."\

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -9,88 +9,77 @@ def accumulate_spatial(pos, **kwargs):
     """
     Given a list of positions, create a histogram of those positions. The
     resulting histogram is typically referred to as a map.
-    
+
     The complexity in this function comes down to selecting where the edges of
-    the arena are, and generating the bins within those limits. 
-    
+    the arena are, and generating the bins within those limits.
+
     The histogram bin edges must be defined in one of 3 different ways:
         * bin_width : based on the keyword `arena_size`, the number of bins will
-        be calculated as 
+        be calculated as:
             opexebo.general.bin_width_to_bin_number
         The histogram will use num_bins between the minimum and maximum of the
         positions (or `limit` if provided)
-        
         * bin_number : the histogram will use bin_number of bins between the
         minimum and maximum of the positions (or `limit` if provided)
-        
         * bin_edges : the histogram will use the provided bin_edge arrays
-    
-    Either zero or one of the three bin_* keyword arguments must be defined. 
+
+    Either zero or one of the three bin_* keyword arguments must be defined.
     If none are defined, then a default bin_width is used. If more than 1 is
     defined, an error is raised
 
     Parameters
     ----------
-    pos : np.ndarray
-        Nx1 or Nx2 array of positions associated with z
-        x = pos[0,:]
-        y = pos[1,:]
-        This matches the simplest input creation:
-            pos = np.array( [x, y] )
-   kwargs
-        bin_width : float. 
-            Bin size in cm. Bins are always assumed square default 2.5 cm. If 
-            bin_width is supplied, `limit` must also be supplied. One of 
-            `bin_width`, `bin_number`, `bin_edges` must be provided
-        bin_number: int or tuple of int
-            Number of bins. If provided as a tuple, then (x_bins, y_bins). One
-            of `bin_width`, `bin_number`, `bin_edges` must be provided
-        bin_edges: array-like
-            Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
-            One of `bin_width`, `bin_number`, `bin_edges` must be provided
-            Dimensions of arena (in cm)
-            For a linear track, length
-            For a circular arena, diameter
-            For a square arena, length or (length, length)
-            For a non-square rectangle, (length1, length2)
-            In this function, a circle and a square are treated identically.
-        limits : tuple or np.ndarray
-            (x_min, x_max) or (x_min, x_max, y_min, y_max)
-            Provide concrete limits to the range over which the histogram searches
-            Any observations outside these limits are discarded
-            If no limits are provided, then use np.nanmin(data), np.nanmax(data)
-            to generate default limits.
-            As is standard in python, acceptable values include the lower bound
-            and exclude the upper bound
-        arena_size : float or tuple of floats. 
-            Dimensions of arena (in cm)
-            For a linear track, length
-            For a circular arena, diameter
-            For a square arena, length or (length, length)
-            For a non-square rectangle, (length1, length2)
-            In this function, a circle and a square are treated identically.
+    pos: np.ndarray
+        Nx1 or Nx2 array of positions  in row-major format, i.e. `x` = pos[0],
+        `y` = pos[1]. This matches the simplest input creation pos = np.array( [x, y] )
+    bin_width: float
+        Bin size in cm. Bins are always assumed square default 2.5 cm. If
+        bin_width is supplied, `limit` must also be supplied. One of
+        `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_number: int or tuple of int
+        Number of bins. If provided as a tuple, then (x_bins, y_bins). One
+        of `bin_width`, `bin_number`, `bin_edges` must be provided
+    bin_edges: array-like
+        Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
+        One of `bin_width`, `bin_number`, `bin_edges` must be provided
+        Dimensions of arena (in cm)
+        For a linear track, length
+        For a circular arena, diameter
+        For a square arena, length or (length, length)
+        For a non-square rectangle, (length1, length2)
+        In this function, a circle and a square are treated identically.
+    limits: tuple or np.ndarray
+        (x_min, x_max) or (x_min, x_max, y_min, y_max)
+        Provide concrete limits to the range over which the histogram searches
+        Any observations outside these limits are discarded
+        If no limits are provided, then use np.nanmin(data), np.nanmax(data)
+        to generate default limits.
+        As is standard in python, acceptable values include the lower bound
+        and exclude the upper bound
+    arena_size: float or tuple of floats
+        Dimensions of arena (in cm)
+        For a linear track, length
+        For a circular arena, diameter
+        For a square arena, length or (length, length)
+        For a non-square rectangle, (length1, length2)
+        In this function, a circle and a square are treated identically.
 
     Returns
     -------
-    hist : np.ndarray
+    hist: np.ndarray
         1D or 2D histogram of the occurrences of the input observations
         Dimensions given by arena_size/bin_width
         Not normalised - each cell gives the integer number of occurrences of
         the observation in that cell
-    edges : list-like
-        x, or (x, y), where x, y are 1d np.ndarrays
-        Here x, y correspond to the output histogram
+    edges: list-like
+        `x`, or (`x`, `y`), where `x`, `y` are 1d np.ndarrays
+        Here `x`, `y` correspond to the output histogram
 
-    See also
+    Notes
     --------
     BNT.+analyses.map()
 
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     """
 
     # Check correct inputs:
@@ -98,13 +87,12 @@ def accumulate_spatial(pos, **kwargs):
     if dims not in (1, 2):
         raise ValueError("pos should have either 1 or 2 dimensions. You have"\
                          " provided %d dimensions." % dims)
-    
-    
+
     # Get kwargs values
     debug = kwargs.get("debug", False)
     arena_size = kwargs.get("arena_size")
     limits = kwargs.get("limits", None)
-    if type(limits) not in (tuple, list, np.ndarray, type(None)):
+    if not isinstance(limits, (tuple, list, np.ndarray, type(None))):
         raise ValueError("You must provide an array-like 'limits' value, e.g."\
           " (x_min, x_max, y_min, y_max). You provided type %s" % type(limits))
 
@@ -136,8 +124,9 @@ def accumulate_spatial(pos, **kwargs):
         # First priority: use predefined bin_edges
         # Remember - user provides (x, y), but histogram needs (y, x)
         if is_2d:
-            if type(bin_edges) not in (tuple, list, np.ndarray):
-                raise ValueError("keyword 'bin_edges' must be either a tuple or list (of np.ndarrays), or a 2D array")
+            if not isinstance(bin_edges, (tuple, list, np.ndarray)):
+                raise ValueError("keyword 'bin_edges' must be either a tuple or list"\
+                                 " (of np.ndarrays), or a 2D array")
         else:
             if not isinstance(bin_edges, np.ndarray):
                 raise ValueError("Keyword 'bin_edges' must be a numpy array for a 1D histogram")
@@ -146,28 +135,32 @@ def accumulate_spatial(pos, **kwargs):
 
     elif bool(bin_width):
         # Calculate the number of bins based on the requested width and arena_size
-        # Then calculate the actual bin edges that this would give, based on expanding from top left.
-        # This returns in format (x, y) -> need to covnert for numpy
+        # Then calculate the actual bin edges that this would give, based on expanding from top left
+        # Given arena size in (x, y), this also returns in (x, y) -> have to convert for Numpy
         num_bins = bin_width_to_bin_number(arena_size, bin_width)
         if limits is None:
             # Handle the case that limits is not provided, i.e. is None
-            lim = (0,0,0,0)
+            lim = (0, 0, 0, 0)
         else:
             lim = limits
         if is_2d:
             # Have to swap to (y, x)
             bins = (np.linspace(0, arena_size[1], num_bins[1]+1) + lim[2],
                     np.linspace(0, arena_size[0], num_bins[0]+1) + lim[0])
-            
-            #[np.linspace(0, arena_size[i], num_bins[i]+1) + lim[2*i] for i in [-1, 0]] # this handles the (x, y) -> (y, x) swap
         else:
             bins = np.linspace(0, arena_size, num_bins+1) + (lim[0])
         debug_bin_type = "bin_width"
 
     elif bool(bin_number):
-        if type(bin_number) not in (int, tuple, list, np.ndarray):
-            raise ValueError("Keyword 'bin_number' must be an integer, or an array-like of integers.")
-        bins = bin_number
+        if isinstance(bin_number, int):
+            bins = bin_number
+        elif isinstance(bin_number, (tuple, list, np.ndarray)):
+            # If an array, we expect to recieve (x, y)
+            # Have to convert for the Numpy standard of (y, x)
+            bins = (bin_number[1], bin_number[0])
+        else:
+            raise ValueError("Keyword 'bin_number' must be an integer, or an"\
+                             " array-like of integers.")
         debug_bin_type = "bin_number"
 
     if debug:
@@ -175,13 +168,13 @@ def accumulate_spatial(pos, **kwargs):
         print(f"Binning type: {debug_bin_type}")
         print(f"bins : {bins}")
 
-
     # Make the histogram
     if is_2d:
         x = pos[0]
         y = pos[1]
         if limits is None:
-            limits = np.array([np.nanmin(y), np.nanmax(y)*1.001, np.nanmin(x), np.nanmax(x)*1.001]).reshape(2,2)
+            limits = np.array([np.nanmin(y), np.nanmax(y)*1.001, np.nanmin(x),
+                               np.nanmax(x)*1.001]).reshape(2, 2)
             # numpy convention: (y, x)
             if debug:
                 print("No limits found. Calculating based on min/max")
@@ -189,13 +182,13 @@ def accumulate_spatial(pos, **kwargs):
             raise ValueError("You must provide a 4-element 'limits' value for a"\
                              " 2D map. You provided %d elements" % len(limits))
         else:
-            limits = np.flipud(np.array(limits).reshape(2,2))
+            limits = np.flipud(np.array(limits).reshape(2, 2))
             # the flipud swaps x and y - rememebr, numpy convention that (y, x)
-        in_range = np.logical_and( 
-                np.logical_and(
-                        np.greater_equal(y, limits[0, 0]), np.less(y, limits[0, 1])),
-                np.logical_and(
-                        np.greater_equal(x, limits[1, 0]), np.less(x, limits[1, 1])) )
+        in_range = np.logical_and(np.logical_and(np.greater_equal(y, limits[0, 0]), 
+                                                 np.less(y, limits[0, 1])),
+                                  np.logical_and(np.greater_equal(x, limits[1, 0]), 
+                                                 np.less(x, limits[1, 1]))
+                                  )
         # the simple operator ">= doesn't respect Masked Arrays
         # As of 2019, it does actually behave correctly (NaN is invalid and so
         # is removed), but I would prefer to be explicit

--- a/opexebo/general/accumulateSpatial.py
+++ b/opexebo/general/accumulateSpatial.py
@@ -13,15 +13,16 @@ def accumulate_spatial(pos, **kwargs):
     The complexity in this function comes down to selecting where the edges of
     the arena are, and generating the bins within those limits.
 
-    The histogram bin edges must be defined in one of 3 different ways:
-        * bin_width : based on the keyword `arena_size`, the number of bins will
-        be calculated as:
-            opexebo.general.bin_width_to_bin_number
-        The histogram will use num_bins between the minimum and maximum of the
-        positions (or `limit` if provided)
-        * bin_number : the histogram will use bin_number of bins between the
-        minimum and maximum of the positions (or `limit` if provided)
-        * bin_edges : the histogram will use the provided bin_edge arrays
+    The histogram bin edges must be defined in one of 3 different ways
+    
+        * bin_width: based on the keyword `arena_size`, the number of bins will
+          be calculated as
+            `opexebo.general.bin_width_to_bin_number`
+          The histogram will use `num_bins` between the minimum and maximum of the
+          positions (or `limit` if provided)
+        * bin_number: the histogram will use bin_number of bins between the
+          minimum and maximum of the positions (or `limit` if provided)
+        * bin_edges: the histogram will use the provided `bin_edg`e arrays
 
     Either zero or one of the three bin_* keyword arguments must be defined.
     If none are defined, then a default bin_width is used. If more than 1 is
@@ -30,24 +31,18 @@ def accumulate_spatial(pos, **kwargs):
     Parameters
     ----------
     pos: np.ndarray
-        Nx1 or Nx2 array of positions  in row-major format, i.e. `x` = pos[0],
-        `y` = pos[1]. This matches the simplest input creation pos = np.array( [x, y] )
+        1D or 2D array of positions  in row-major format, i.e. `x` = pos[0],
+        `y` = pos[1]. This matches the simplest input creation pos = np.array( [`x`, `y`] )
     bin_width: float
-        Bin size in cm. Bins are always assumed square default 2.5 cm. If
-        bin_width is supplied, `limit` must also be supplied. One of
-        `bin_width`, `bin_number`, `bin_edges` must be provided
+        Bin size in cm. Default 2.5cm. If bin_width is supplied, `limit` must
+        also be supplied. One of `bin_width`, `bin_number`, `bin_edges` must be
+        provided
     bin_number: int or tuple of int
-        Number of bins. If provided as a tuple, then (x_bins, y_bins). One
+        Number of bins. If provided as a tuple, then `(x_bins, y_bins)`. One
         of `bin_width`, `bin_number`, `bin_edges` must be provided
     bin_edges: array-like
         Edges of the bins. Provided either as `edges` or `(x_edges, y_edges)`.
         One of `bin_width`, `bin_number`, `bin_edges` must be provided
-        Dimensions of arena (in cm)
-        For a linear track, length
-        For a circular arena, diameter
-        For a square arena, length or (length, length)
-        For a non-square rectangle, (length1, length2)
-        In this function, a circle and a square are treated identically.
     limits: tuple or np.ndarray
         (x_min, x_max) or (x_min, x_max, y_min, y_max)
         Provide concrete limits to the range over which the histogram searches
@@ -58,11 +53,9 @@ def accumulate_spatial(pos, **kwargs):
         and exclude the upper bound
     arena_size: float or tuple of floats
         Dimensions of arena (in cm)
-        For a linear track, length
-        For a circular arena, diameter
-        For a square arena, length or (length, length)
-        For a non-square rectangle, (length1, length2)
-        In this function, a circle and a square are treated identically.
+            * For a linear track, length
+            * For a circular arena, diameter
+            * For a rectangular arena, length or (length, length)
 
     Returns
     -------
@@ -75,6 +68,10 @@ def accumulate_spatial(pos, **kwargs):
         `x`, or (`x`, `y`), where `x`, `y` are 1d np.ndarrays
         Here `x`, `y` correspond to the output histogram
 
+    See Also
+    --------
+    opexebo.general.bin_width_to_bin_number
+    
     Notes
     --------
     BNT.+analyses.map()

--- a/opexebo/general/binWidth_to_binNumber.py
+++ b/opexebo/general/binWidth_to_binNumber.py
@@ -9,14 +9,14 @@ def bin_width_to_bin_number(length, bin_width):
     
     Parameters
     ----------
-    length : float or np.ndarray
+    length: float or np.ndarray
         Length of a side to be divided into equally spaced bins
-    bin_width : float
+    bin_width: float
         Dimension of a square bin or pixel
     
     Returns
     -------
-    num_bins : int or np.ndarray
+    num_bins: int or np.ndarray
         Same type as `length`. Integer number of bins.
     '''
     if type(length) in (list, tuple):

--- a/opexebo/general/circular_mask.py
+++ b/opexebo/general/circular_mask.py
@@ -31,6 +31,10 @@ def circular_mask(axes, diameter, **kwargs):
     distance_map: np.ndarray
         2D float array of same size. Values are the distance of the centre of
         the pixel from the origin
+    angular_map: np.ndarray
+        2D float array of the same size. Values are the angle from the origin
+        to the pixel, in degrees. Angles are given with 0° pointing to increasing
+        `y`, clockwise. 
     '''
     origin = kwargs.get("origin", (0,0))
     radius = diameter / 2
@@ -39,5 +43,7 @@ def circular_mask(axes, diameter, **kwargs):
     y_centres = axes[1][:-1] + (bin_width[1] / 2) - origin[1]
     X, Y = np.meshgrid(x_centres, y_centres)
     distance_map = np.sqrt(np.power(X,2) + np.power(Y,2))
-    in_field = distance_map<=radius
-    return in_field, distance_map
+    angular_map_rad = np.arctan2(Y, X).transpose()
+    angular_map_deg = np.degrees(angular_map_rad) % 360
+    in_field = (distance_map <= radius)
+    return in_field, distance_map, angular_map_deg

--- a/opexebo/general/circular_mask.py
+++ b/opexebo/general/circular_mask.py
@@ -1,0 +1,44 @@
+
+import numpy as np
+
+def circular_mask(axes, diameter, **kwargs):
+    '''Given a set of axes, construct a circular mask defining pixels as within
+    or without a circular arena.
+    
+    A pixel is assumed to be inside the circle iff the centre-point is within
+    the radius of the circle. For small radii, this will result in including
+    pixels with <50% of their area inside. 
+    
+    Parameters
+    ----------
+        axes : list of np.ndarray
+            [x, y] - pair of nd-arrays defining the _edges_ of the pixels. This
+            is the return value from np.histogram2d, for instance
+            Each one is size+1 relative to the number of pixels
+            This function assumes that each dimension has a CONSTANT bin width,
+            although each dimension may have its own bin width. 
+       diameter : float
+           diameter of the circle
+        keywords
+            origin : list of floats
+                [x,y] co-ordinates of the centre of the arena.
+                Optional, defaults to (0,0)
+    
+    Returns
+    -------
+    in_field : np.ndarray
+        2D boolean array of dimensions (axes[0].size-1, axs[1].size-1)
+        Values are TRUE if INSIDE circle and FALSE if OUTSIDE
+    distance_map : np.ndarray
+        2D float array of same size.
+        Values are the distance of the centre of the pixel from the origin
+    '''
+    origin = kwargs.get("origin", (0,0))
+    radius = diameter / 2
+    bin_width = [np.mean(np.diff(ax)) for ax in axes]
+    x_centres = axes[0][:-1] + (bin_width[0] / 2) - origin[0]
+    y_centres = axes[1][:-1] + (bin_width[1] / 2) - origin[1]
+    X, Y = np.meshgrid(x_centres, y_centres)
+    distance_map = np.sqrt(np.power(X,2) + np.power(Y,2))
+    in_field = distance_map<=radius
+    return in_field, distance_map

--- a/opexebo/general/circular_mask.py
+++ b/opexebo/general/circular_mask.py
@@ -11,27 +11,26 @@ def circular_mask(axes, diameter, **kwargs):
     
     Parameters
     ----------
-        axes : list of np.ndarray
-            [x, y] - pair of nd-arrays defining the _edges_ of the pixels. This
-            is the return value from np.histogram2d, for instance
+        axes: list of np.ndarray
+            [`x`, `y`] - pair of nd-arrays defining the edges of the pixels. This
+            is the return value from np.histogram2d, for instance. 
             Each one is size+1 relative to the number of pixels
             This function assumes that each dimension has a CONSTANT bin width,
             although each dimension may have its own bin width. 
-       diameter : float
+       diameter: float
            diameter of the circle
-        keywords
-            origin : list of floats
-                [x,y] co-ordinates of the centre of the arena.
-                Optional, defaults to (0,0)
+       origin: list of floats
+           [`x`, `y`] co-ordinates of the centre of the arena. Optional,
+           defaults to `(0,0)`
     
     Returns
     -------
-    in_field : np.ndarray
-        2D boolean array of dimensions (axes[0].size-1, axs[1].size-1)
-        Values are TRUE if INSIDE circle and FALSE if OUTSIDE
-    distance_map : np.ndarray
-        2D float array of same size.
-        Values are the distance of the centre of the pixel from the origin
+    in_field: np.ndarray
+        2D boolean array of dimensions `(axes[0].size-1, axs[1].size-1)`
+        Values are `true` if INSIDE circle and `false` if OUTSIDE
+    distance_map: np.ndarray
+        2D float array of same size. Values are the distance of the centre of
+        the pixel from the origin
     '''
     origin = kwargs.get("origin", (0,0))
     radius = diameter / 2

--- a/opexebo/general/fitEllipse.py
+++ b/opexebo/general/fitEllipse.py
@@ -49,7 +49,7 @@ def fit_ellipse(X, Y):
         Ellipse orientation (in radians)
 
 
-    See also
+    Notes
     --------
     BNT.+general.fitEllipse
     opexebo.analysis.gridscore

--- a/opexebo/general/normxcorr2_general.py
+++ b/opexebo/general/normxcorr2_general.py
@@ -13,16 +13,19 @@ import numpy as np
 import numpy.matlib  # Not included in the default numpy namespace
 from scipy.signal import convolve2d
 
-def normxcorr2_general(map):
+def normxcorr2_general(array):
     """Calculate spatial autocorrelation.
 
-    Python adaption of more general matlab function for calculating cross 
-    correlation
+    Python implementation of the Matlab `generalized-normalized cross correlation`
+    function, adapted by Vadim Frolov. Some generality was abandoned in the adaption
+    as unnecessary for autocorrelogram calculation.
+    
+    For the original function, see https://se.mathworks.com/matlabcentral/fileexchange/29005-generalized-normalized-cross-correlation
 
     Parameters
     ----------
-    map: NxM matrix
-        firing map. map is not necessary a numpy array. Must not contain NaNs!
+    array: NxM matrix
+        firing array. array is not necessary a numpy array. Must not contain NaNs!
 
     Returns
     -------
@@ -30,12 +33,14 @@ def normxcorr2_general(map):
         Resulting correlation matrix
     """
 
-    if not isinstance(map, np.ndarray):
-        map = np.array(map)
+    if not isinstance(array, np.ndarray):
+        array = np.array(array)
+    if not np.sum(np.isfinite(array)) == array.size:
+        raise ValueError("Input array contains NaN values.")
 
     requiredNumberOfOverlapPixels = 0
-    A = _shiftData(map)
-    T = _shiftData(map)
+    A = _shiftData(array)
+    T = _shiftData(array)
 
     numberOfOverlapPixels = _local_sum(np.ones(A.shape), T.shape[0], T.shape[1])
 

--- a/opexebo/general/peakSearch.py
+++ b/opexebo/general/peakSearch.py
@@ -16,35 +16,39 @@ def peak_search(image, **kwargs):
     """Given a 1D or 2D array, return a list of co-ordinates of the local 
     maxima or minima
     
-    Multiple searching techniques are provided
+    Multiple searching techniques are provided:
+        
+        * `default`: uses `skimage.morphology.get_maxima`
+        * `sep`: uses the Python wrapper to the Source Extractor astronomy tool
+          to identify peaks
     
     Parameters
     ----------
-    image : np.ndarray
+    image: np.ndarray
         1D or 2D array of data
-    kwargs
-        search_method : str
-        maxima : bool
-            If True, return the local maxima. Else, return the local minima.
-            Default True
-        mask : np.ndarray
-            Same dimensions as image, True where values of image are to be ignored
-            Only relevant to search method 'sep'
-        null_background : bool
-            Set the image background to zero for calculation purposes
-            Only relevant to 'sep' : astronomical images typically have both a 
-            background gradient and randomised noise in the image. SEP can
-            generate a compensation for this - but the images we typically work
-            with do not suffer the same problem. This should generally be True,
-            unless you know exactly why it shouldn't be. 
+    search_method : str, optional, {"default", "sep"}
+    mask : np.ndarray
+        Array of masked locations in the image with the same dimensions.
+        Locations where the mask value is True are ignored for the purpose of
+        searching.
+    maxima: bool, optional
+        [`default` search method only] Define whether to search for maxima or
+        minima in the provided array
+    null_background: bool
+        [`sep` search method only] Set the image background to zero for
+        calculation purposes rather than attempt to calculate a background
+        gradient. This should generally be True, as our images are not directly
+        comparable to standard telescope output
+    threshold : float, optional
+        [`sep` search method only] Threshold for identifiying maxima area
     
     Returns
     -------
-    peak_coords : tuple
+    peak_coords: tuple
         Co-ordinates of peaks, in the form ((x0, x1, x2...), (y0, y1, y2...))
     
     
-    See also
+    Notes
     --------
     Copyright (C) 2019 by Simon Ball
     """
@@ -117,7 +121,6 @@ def _peak_search_sep_wrapper(firing_map, **kwargs):
     If the user tries to invoke the 'sep' routines, this will try to do so
     If it fails due to ModuleNotFound, it will use the default algorithm instead
     with a warning to the user
-    
     '''
     try:
         import sep
@@ -148,7 +151,7 @@ def _peak_search_sep(firing_map, **kwargs):
     import sep
     
     mask = kwargs.get("mask", np.zeros(firing_map.shape, dtype=bool))
-    null_background = kwargs.get("null_background", False)
+    null_background = kwargs.get("null_background", True)
     threshold = kwargs.get("threshold", 0.2)
     
     tmp_firing_map = firing_map.copy('C')

--- a/opexebo/general/powerSpectrum.py
+++ b/opexebo/general/powerSpectrum.py
@@ -4,42 +4,41 @@ from scipy import signal
 import opexebo.defaults as default
 
 
-def power_spectrum(values, time_stamps, **kwargs):
+def power_spectrum(values, time_stamps, sampling_frequency, **kwargs):
     '''
     Calculate the power spectrum of a time-series of data
     
     Parameters
     ----------
-    values : np.ndarray
+    values: np.ndarray
         Amplitude of time series at times `time_stamps`. Must be sampled at a
         constant frequency
-    time_stamps : np.ndarray
+    time_stamps: np.ndarray
         Time stamps of time-series. Must be the same length as `values`. 
         Assumed to be in [seconds]
-    kwargs
-        method : str
-            Method for calculating a power spectrum. Accepted values are:
-            ["welch", "fft"]. Defaults to "welch"
-        fs : float
-            Sampling rate. Assumed to be in [Hz]
-        scale : str
-            Should the power spectrum be returned in a linear form 
-            propto v**2/sqrt(Hz)) ("linear"); 
-            or decibel scale (dB/sqrt(Hz)) ("log")
-            Defaults to "linear"
-        resolution : float
-            Desired output frequency resolution. Applicable only to Welch's 
-            method. Due to the averaging effect of Welch's method, this sets
-            the "effective" resolution, which is NOT the same as the minimum
-            difference in `frequencies`
-            Default 1 [Hz]. Values lower than 1/(time_series_duration) are 
-            meaningless
+    sampling_frequency: float
+        Sampling rate. Assumed to be in [Hz]
+    method: str, optional, {"welch", "fft"}
+        Method for calculating a power spectrum. Accepted values are:
+        ["welch", "fft"]. Defaults to "welch"
+    scale: str, optiona, {"linear", "log"}
+        Should the power spectrum be returned in a linear form 
+        propto v**2/sqrt(Hz)) ("linear"); 
+        or decibel scale (dB/sqrt(Hz)) ("log")
+        Defaults to "linear"
+    resolution: float
+        Desired output frequency resolution. Applicable only to Welch's 
+        method. Due to the averaging effect of Welch's method, this sets
+        the "effective" resolution, which is NOT the same as the minimum
+        difference in `frequencies`
+        Default 1 [Hz]. Values lower than 1/(time_series_duration) are 
+        meaningless
     
     Returns
     -------
-    frequencies : np.ndarray
+    frequencies: np.ndarray
         Discrete Fourier Transform sample frequencies
-    power_spectrum : np.ndarray
+    power_spectrum: np.ndarray
         Power spectral density at that sample frequency
     '''
     method = kwargs.get("method", default.power_spectrum_method).lower()
@@ -55,7 +54,7 @@ def power_spectrum(values, time_stamps, **kwargs):
     else:
         raise NotImplementedError(f"Method '{method}' not implemented")
 
-    frequencies, power_spectrum = func(values, time_stamps, **kwargs)
+    frequencies, power_spectrum = func(values, time_stamps, sampling_frequency, **kwargs)
 
     if scale == "log":
         power_spectrum = 20 * np.log10(power_spectrum)
@@ -65,13 +64,12 @@ def power_spectrum(values, time_stamps, **kwargs):
 
 
 
-def _power_spectrum_welch(values, time_stamps, **kwargs):
+def _power_spectrum_welch(values, time_stamps, sampling_frequency, **kwargs):
     '''Use Welch's method to calculate a power spectrum for a time-series of
     data
     '''
     resolution_multiplier = 32 
     output_resolution = kwargs.get("resolution", default.psd_resolution_welch)
-    sampling_frequency = kwargs.get("fs")
     
     n = sampling_frequency * resolution_multiplier / output_resolution
     
@@ -83,11 +81,10 @@ def _power_spectrum_welch(values, time_stamps, **kwargs):
 
 
 
-def _power_spectrum_fft(values, time_stamps, **kwargs):
+def _power_spectrum_fft(values, time_stamps, sampling_frequency, **kwargs):
     '''Calculate the simplest, noisiest, power spectrum by taking the real
     component of the fast Fourier transform of the time-series  
     '''
-    sampling_frequency = kwargs.get("fs")
     sampling_time_period = 1/sampling_frequency
     
     amplitude_spectral_density = np.abs(np.fft.rfft(values))

--- a/opexebo/general/shuffle.py
+++ b/opexebo/general/shuffle.py
@@ -6,17 +6,16 @@ import time
 def shuffle(times, offset_lim, iterations, **kwargs):
     '''
     Increment the provided time series by a random period of time in order to 
-    destroy the correlation between spike times and animal behaviour. 
-    
-    STATUS : EXPERIMENTAL
+    destroy the correlation between spike times and animal behaviour.
     
     The increment behaves circularly
-    * initially, we have two time series, Tracking and SpikeTimes, both with 
-    values in the range [t0, t1]. 
-    * after incrementing by T, we have Tracking in [t0, t1] and SpikeTimes
-    in [t0+T, t1+T]
-    * Take all spike times in the range [t1, t1+T] and map back to [t0, t0+T]
-    by subtracting (t1-t0)
+    
+    * Initially, we have two time series, Tracking and SpikeTimes, both with 
+      values in the range `[t0, t1]`. 
+    * After incrementing the SpikeTimes by T, we have Tracking in `[t0, t1]`
+      and SpikeTimes in `[t0+T, t1+T]`.
+    * Take all spike times in the range `[t1, t1+T]` and map back to `[t0, t0+T]`
+      by subtracting `(t1-t0)`
     
     The end result should be a series of times also in the range [t0, t1], 
     with the same intervals between times, but the exact value of those times
@@ -24,42 +23,43 @@ def shuffle(times, offset_lim, iterations, **kwargs):
     first, last) will noe have zero spacing
     
     The random numbers are drawn from a pseudorandom, uniform, distribution in 
-    the range [offset_lim, t1-offset_lim]
+    the range `[offset_lim, t1-offset_lim]`
         
     
     Parameters
     ----------
-    times : np.ndarray
-        Nx1 array of times
-    offset_lim : float
+    times: np.ndarray
+        1D array of times to be shuffled
+    offset_lim: float
         Defines the range of values by which each iteration can be offset. Each
-        iteration will have an offset in [offset_lim, max(times)-offset_lim]
-    iterations : int
+        iteration will have an offset in `[offset_lim, max(times)-offset_lim]`
+    iterations: int
         How many copies of times should be returned (each copy incremented by a
-        random offset limited by offset_lim)
-    kwargs
-        'debug' : bool
-            Enable additional debugging output
-        'tracking_range' : array_like
-            The time range over which tracking behaviour exists, defining the
-            times at which spike indexes are looped back on themselves
-            This can be provided either as a 2-element tuple (t0, t1), or as 
-            the entire list of tracking timestamps. In each case, the min and 
-            max values are used as t0, t1
-            If no values are provided, then the first and last spike times
-            are used. This is not desirable behaviour, since it will then guarantee 
-            that in the shuffled output, two spikes will occur simultaneously
+        random offset limited by `offset_lim`)
+    tracking_range: array_like, optional
+        The time range over which tracking behaviour exists, defining the
+        times at which spike indexes are looped back on themselves
+        This can be provided either as a 2-element tuple `[t0, t1]`, or as 
+        the entire list of tracking timestamps. In each case, the min and 
+        max values are used as `t0`, `t1`.
+        If no values are provided, then the first and last spike times
+        are used. This is not desirable behaviour, since it will then guarantee 
+        that in the shuffled output, two spikes will occur simultaneously
+    debug: bool, optional
+        Enable additional debugging output
     
     Returns
     -------
-    output : np.ndarray
+    output: np.ndarray
         iterations x N array of times. To access a single iteration, output[i,:] or output[i]
     increments : np.ndarray
-        1xN array of offset values used.
+        1D array of offset values used.
     
-    See also
+    Notes
     --------
     BNT.+scripts.shuffling around line 350
+    
+    Copyright (C) 2019 by Simon Ball
     '''
     
     # Check values
@@ -164,11 +164,11 @@ def shuffle(times, offset_lim, iterations, **kwargs):
     
     return output, increments
     
-if __name__ == '__main__':
-    times = [2, 12, 27, 54, 82, 113, 115, 207, 300]
-    t_min = 20
-    iterations = 3
-    s = shuffle(times, t_min, iterations, debug=False, tracking_range=(0,349))
-    #print(s)
+#if __name__ == '__main__':
+#    times = [2, 12, 27, 54, 82, 113, 115, 207, 300]
+#    t_min = 20
+#    iterations = 3
+#    s = shuffle(times, t_min, iterations, debug=False, tracking_range=(0,349))
+#    #print(s)
 
     

--- a/opexebo/general/smooth.py
+++ b/opexebo/general/smooth.py
@@ -42,43 +42,35 @@ def smooth(data, sigma, **kwargs):
 
     Parameters:
     ----------
-    data : np.ndarray or np.ma.MaskedArray
+    data: np.ndarray or np.ma.MaskedArray
         Data that will be smoothed
-    sigma : float
+    sigma: float
         Standard deviations for Gaussian kernel in units of pixels/bins
-    kwargs
-        mask_fill : float
-            The value that masked locations should be treated as
-            This can either be provided as an absolute number (e.g. 0), or nan
-            If nan, then each masked location will get a value by interpolating
-            from nearby cells. This will only apply if the input is a
-            MaskedArray to start with. If the input is a standard np.ndarray,
-            then no values will be substituted, even if there are nans present.
-        circle : bool
-            If True, then smoothing at the edge of the array will be handled in
-            a circular manner, i.e. the value to the left of data[0] will be
-            data[-1]
-            If False, the edge will be handled by padding with values equal to
-            the boundary value. 
-            Default False
+    mask_fill: float, optional
+        The value that masked locations should be treated as
+        This can either be provided as an absolute number (e.g. 0), or nan
+        If nan, then each masked location will get a value by interpolating
+        from nearby cells. This will only apply if the input is a
+        MaskedArray to start with. If the input is a standard np.ndarray,
+        then no values will be substituted, even if there are nans present.
+    circle: bool, optional
+        If True, then smoothing at the edge of the array will be handled in
+        a circular manner, i.e. the value to the left of data[0] will be
+        data[-1]. If False, the edge will be handled by padding with values
+        equal to the boundary value. Default False
 
     Returns
     -------
-    smoothed_data : np.ndarray or np.ma.MaskedArray
+    smoothed_data: np.ndarray or np.ma.MaskedArray
         Smoothed data
 
-    See also
+    Notes
     --------
     BNT.+general.smooth
     http://docs.astropy.org/en/stable/convolution/index.html
     https://github.com/astropy/astropy/issues/6511
 
     Copyright (C) 2019 by Simon Ball
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
     '''
     d = data.ndim
     if  d == 2:

--- a/opexebo/general/spatialCrossCorrelation.py
+++ b/opexebo/general/spatialCrossCorrelation.py
@@ -13,32 +13,35 @@ def spatial_cross_correlation(arr_0, arr_1, **kwargs):
 
     Parameters
     ----------
-    arr_0 : np.ndarray
+    arr_0: np.ndarray
         1d or 2d array. Must either contain no NaNs, or be an np.ma.MaskedArray
         with NaN values masked. 
     
-    arr_1 : np.ndarray
-        2nd array to correlate with. Must have the same dimensions as ratemap_0
+    arr_1: np.ndarray
+        2nd array to correlate with. Must have the same dimensions as `arr_0`
     
-    kwargs
-        row_major : bool
-            If the arrays are 2D, process first by row, or first by column.
-            Default True
+    Other Parameters
+    ----------------
+    row_major: bool, optional
+        If the arrays are 2D, process first by row, or first by column.
+        Default `True`
 
     Returns
     -------
-    output_single : float
+    output_single: float
         Pearson correlation coefficient between entire arrays. 2d input arrays
         are flattened to 1d to calculate
-    output_array : np.ndarray
+    output_array: np.ndarray
         1D array of pearson correlation coefficients, where the i'th value is
         the coefficient between the i'th rows (if row_major), or the i'th columns
         of the two arrays
         Return value is np.nan if 1d arrays are supplied
 
-    See Also
+    Notes
     --------
-    BNT.+analyses.spatialCrossCorrelation
+    BNT.+analyses.spatialCrossCorrelation()
+
+    Copyright (C) 2019 by Simon Ball
     '''
     debug = kwargs.get("debug", False)
     arr_0 = _check_single_array(arr_0, 0, **kwargs)

--- a/opexebo/general/upsample.py
+++ b/opexebo/general/upsample.py
@@ -1,0 +1,153 @@
+import numpy as np
+import skimage.transform
+
+
+def upsample(array, upscale, **kwargs):
+    '''A MaskedArray aware upsampling routine. 
+    
+    `skimage` provides more reliable methods for interpolated upsampling of simple
+    ndarrays. However, this is not appropriate to MaskedArrays, i.e. where
+    certain locations have invalid values that should not expand.
+    
+    For non-masked arrays, this function can optionally rely on the `skimage`
+    routine allowing fractional upscaling. For MaskedArrays, integer upscaling
+    is enforced, with no interpolation
+    
+    Parameters
+    ----------
+    array: array-like
+        Supports `list`, `tuple`, `np.ndarray` or `np.ma.MaskedArray`. Supports
+        1d and 2d (2d for true arrays only). If the array contains any non-finite
+        values, or is a MaskedArray, then integer upscaling is enforced
+    upscale: int or float
+        Upscaling factor. The output array shape will be this factor larger.
+        Method of upscaling depends on type(upscale). 
+            * `int` -> integer upscaling with no interpolation
+            * `float` -> upscaling with interpolation
+        Note the type distinction: `type(1) == int`; `type(1.) == float`
+    debug: bool, optional
+        Print out debugging information while running. Default False
+
+    Returns
+    -------
+    new_array : np.ndarray or np.ma.MaskedArray
+        Upsampled array
+    '''
+    ### General handling of the input array
+    # If a tuple or list was provided, convert to an ndarray
+    if isinstance(array, (tuple, list)):
+        array = np.array(array)
+    # Check for invalid values
+    if isinstance(array, np.ndarray):
+        if np.logical_not(np.isfinite(array)).any():
+            # Check for any non-finite elements -> convert to masked array if so
+            array = np.ma.masked_invalid(array)
+        else:
+            pass
+    elif isinstance(array, np.ma.MaskedArray):
+        pass
+    else:
+        raise NotImplementedError(f"Upsampling is not supported for array type {type(array)}")
+
+    debug = kwargs.get("debug", False)
+    
+    if debug:
+        print(f"Array type: {type(array)}")
+        print(f"Upscaling: {upscale}, type {type(upscale)}")
+    
+    #####           Based on the inputs, decide how to proceed
+    # Is the array Masked (then use integer scaling), or not masked (then allow non-integer scaling
+    if isinstance(array, np.ma.MaskedArray):
+        if isinstance(upscale, int):
+            new_array = _integer_upsampling(array, upscale, **kwargs)
+        else:
+            raise NotImplementedError(f"Fractional interpolation is not supported"\
+                                      f" with MaskedArrays. You requested upscaling {upscale}")
+    else:
+        if isinstance(upscale, int):
+            new_array = _integer_upsampling(array, upscale, **kwargs)
+        else:
+            new_array = _fractional_upsampling(array, upscale, **kwargs)
+    
+    return new_array
+
+###############################################################################
+####            Actual calculation functions here
+
+    
+def _integer_upsampling(array, upscale, **kwargs):
+    '''
+    Perform integer upscaling on the provided array. No interpolation
+
+    Each pixel in `array` is replaced by `upscale`x`upscale` pixels of the same
+    value in `new_array`.
+
+    Parameters
+    ----------
+    array: np.ndarray or np.ma.MaskedArray
+        1D or 2D, the array to be scaled
+    upscale: int
+        upscaling factor, >= 1. 1 is an acceptable, though pointless, value -
+        the original array is returned with no modifications
+
+    Returns
+    -------
+    new_array : np.ndarray or np.ma.MaskedArray
+        Same array type as input. 
+    '''
+    if upscale < 1:
+        raise NotImplementedError("upscale must be 1 or higher")
+    elif upscale == 1:
+        new_array = array
+    elif isinstance(array, np.ma.MaskedArray):
+        #In the case of a MaskedArray, upscale the mask and data separately
+        ndata = _integer_upsampling(array.data, upscale, **kwargs)
+        nmask = _integer_upsampling(np.ma.getmaskarray(array), upscale, **kwargs)
+        new_array = np.ma.masked_where(nmask, ndata)
+    else:
+        new_shape = np.array(array.shape) * upscale
+        new_array = np.zeros(new_shape, dtype=array.dtype)
+
+        # 1D
+        if array.ndim == 1:
+            for i in range(upscale):
+                new_array[i:new_shape[0]+i+1-upscale:upscale] = array[:]
+
+        # 2D
+        elif array.ndim == 2:
+            for i in range(upscale):
+                for j in range(upscale):
+                    new_array[i:new_shape[0]+i+1-upscale:upscale,
+                              j:new_shape[1]+j+1-upscale:upscale] = array[:,:]
+        else:
+            raise NotImplementedError(f"Integer upscaling only supports 1D and 2D arrays."\
+                                      f" You provided {array.ndim}D")
+    return new_array
+
+
+def _fractional_upsampling(array, upscale, **kwargs):
+    '''Perform fractional upscaling on the provided array. Since there is no
+    direct mapping from one to many locations, use interpolation to calculate
+    the new values
+    
+    Parameters
+    ----------
+    array: np.ndarray
+        nD array to be scaled
+    upscale: float
+        Scaling factor. Must be > 0
+    
+    Returns
+    -------
+    new_array : np.ndarray
+        Upscaled, interpolated array. Same type and dimensionality as input array
+    '''
+    if upscale == 1:
+        new_array = array
+    elif upscale <= 0:
+        raise ValueError(f"Upscaling not supported for values <= 0 ({upscale})")
+    elif not isinstance(array, np.ndarray):
+        raise ValueError(f"Upscaling is only supported for np.ndarrays. You provided {type(array)}")
+    else:
+        new_array = skimage.transform.rescale(array, upscale)
+    return new_array

--- a/opexebo/general/validateKeyword.py
+++ b/opexebo/general/validateKeyword.py
@@ -92,7 +92,7 @@ def validate_keyword_arena_shape(arena_shape):
     if arena_shape in default.shapes_square:
         # this is ok
         pass
-    elif arena_shape in default.shapes_circ:
+    elif arena_shape in default.shapes_circle:
         # this is ok
         pass
     elif arena_shape in default.shapes_linear:

--- a/opexebo/general/validateKeyword.py
+++ b/opexebo/general/validateKeyword.py
@@ -2,6 +2,9 @@
 
 import numpy as np
 
+import opexebo.defaults as default
+from opexebo.errors import ArgumentError
+
 def validatekeyword__arena_size(kwv, provided_dimensions):
     '''
     Decipher the possible meanings of the keyword "arena_size".
@@ -11,8 +14,8 @@ def validatekeyword__arena_size(kwv, provided_dimensions):
     
     Parameters:
     ----------
-    kw : float or array-like of floats
-        The value given for the keyword "arena_size
+    kw: float or array-like of floats
+        The value given for the keyword `arena_size`
     provided_dimensions : int
         the number of spatial dimensions provided to the original function.
         Acceptable values are 1 or 2
@@ -64,3 +67,40 @@ def validatekeyword__arena_size(kwv, provided_dimensions):
                          " provide either a float or a tuple of 2 floats. Value"\
                          " provided: '%s'" % str(kwv))
     return arena_size, is_2d
+
+
+def validate_keyword_arena_shape(arena_shape):
+    '''
+    Ensure that the arena_shape is a meaningful value
+    
+    Parameters
+    ----------
+    arena_shape : str
+        the value given for the keyword `arena_shape`
+    
+    Returns
+    -------
+    arena_shape : str
+        A value that is guaranteed to be an acceptable member of one of the
+        recognised groups of arena_shapes
+    '''
+    if not isinstance(arena_shape, str):
+        raise ArgumentError("Keyword `arena_shape` must be a string, not type `{type(arena_shape)}`")
+    else:
+        arena_shape = arena_shape.lower()
+    
+    if arena_shape in default.shapes_square:
+        # this is ok
+        pass
+    elif arena_shape in default.shapes_circ:
+        # this is ok
+        pass
+    elif arena_shape in default.shapes_linear:
+        # this is ok
+        pass
+    else:
+        raise NotImplementedError(f"Arena shape '{arena_shape}' not implemented")
+    
+    return arena_shape
+    
+    

--- a/opexebo/tests/test_analysis/test_borderCoverage.py
+++ b/opexebo/tests/test_analysis/test_borderCoverage.py
@@ -11,101 +11,147 @@ import matplotlib.pyplot as plt
 import pytest
 
 import test_helpers as th
+from opexebo.general import circular_mask
 from opexebo.analysis import border_coverage as func
+from opexebo.analysis.borderCoverage import _validate_keyword_walls as validate_func
+from opexebo.errors import ArgumentError
 
 print("=== tests_analysis_border_coverage ===")
 
 ###############################################################################
 ################                MAIN TESTS
 ###############################################################################
-    
 
-def test_perfect_fields():
+def test_validate_func_square_correct_inputs():
+    # Test correct strings
+    # 1-4 characters, should yield the same string in lower case
+    # Resulting string will be in alphabetical order and remove duplicates
+    shape = "s"
+    assert validate_func("TRBL", shape) == 'blrt'
+    assert validate_func("tBr", shape) == "brt"
+    assert validate_func("b", shape) == "b"
+    assert validate_func("bbbb", shape) == "b"
+    assert validate_func("bbbTrBLl", shape) == 'blrt'
+
+def test_validate_func_square_incorrect_inputs():
+    shape = "s"
+    # zero length
+    with pytest.raises(ValueError):
+        validate_func("", shape)
+    # >4 length of unique characters
+    with pytest.raises(ValueError):
+        validate_func("abcdef", shape)
+    # With invalid characters
+    with pytest.raises(ValueError):
+        validate_func("abcd", shape)
+    # angular array
+    with pytest.raises(ArgumentError):
+        validate_func([(15, 35), (270, 360)], shape)
+
+def test_perfect_fields_square():
     '''Perfect field: 100% coverage of wall, zero distance, everywhere else zero'''
+    shape = "s"
     perfect_left_field = np.zeros((40,40))
     perfect_left_field[:,0] = 1
-    left = {"field_map":perfect_left_field}
+    left = {"map":perfect_left_field}
     sw = 1
-    walls= "L"
-    assert(func(left, search_width=sw, walls=walls) == 1)
-    right = {'field_map': np.fliplr(perfect_left_field)}
-    walls="R"
-    assert(func(right, search_width=sw, walls=walls) == 1)
-    top = {"field_map": np.rot90(perfect_left_field)}
-    walls="T"
-    assert(func(top, search_width=sw, walls=walls) == 1)
-    bottom = {"field_map": np.flipud(np.rot90(perfect_left_field))}
-    walls="B"
-    assert(func(bottom, search_width=sw, walls=walls) == 1)
+    assert(func(left, shape, search_width=sw, walls="L") == 1)
+    
+    right = {"map": np.fliplr(perfect_left_field)}
+    assert(func(right, shape, search_width=sw, walls="R") == 1)
+    
+    top = {"map": np.rot90(perfect_left_field)}
+    assert(func(top, shape, search_width=sw, walls="T") == 1)
+    
+    bottom = {"map": np.flipud(np.rot90(perfect_left_field))}
+    assert(func(bottom, shape, search_width=sw, walls="B") == 1)
+    
     # The above verify that the function agrees with a field that is there
     # The below verify that the function correctly identifies that a field is *not* there. 
-    assert(func(left, search_width=sw, walls="TRB") == 1/40)
+    assert(func(left, shape, search_width=sw, walls="TRB") == 1/40)
     print("test_perfect_fields() passed")
     return True
     
-def test_offset_perfect_field():
+def test_offset_perfect_field_square():
     '''Offset field: 100% coverage of wall, NaNs filling space between wall and field, distance 4, all else zero'''
     field = np.zeros((40,40), dtype=float)
     field[:,3] = 1
     field[:, :3] = np.nan
     field = np.ma.masked_invalid(field)
-    print(field)
-    fields = {"field_map":field}
-    sw = 8
-    walls= "L"
-    assert(func(fields, search_width=sw, walls=walls) == 1)
+    fields = {"map":field}
+    shape = "s"
+    assert(func(fields, shape, search_width=8, walls="L") == 1)
     print("test_offset_field() passed")
     return True
 
-def test_partial_field():
+
+def test_partial_field_square():
     '''Fields that do not extend over the whole wall'''
     field = np.zeros((40,40))
     field[:10, 0] = 1
-    fields = {"field_map": field}
+    fields = {"map": field}
     walls = "L"
-    assert(func(fields, walls=walls)==0.25)
+    assert(func(fields, "s", walls=walls)==0.25)
     field[:20, 0] = 1
-    assert(func(fields, walls=walls)==0.5)
+    assert(func(fields, "s", walls=walls)==0.5)
     field[:30, 0] = 1
-    assert(func(fields, walls=walls)==0.75)
+    assert(func(fields, "s", walls=walls)==0.75)
     print("test_partial_field() passed")
     return True
 
-def test_extended_field():
+def test_extended_field_square():
     '''Field extending in two dimensions. Should get different answers depending
     on which wall direction is requested'''
     field = np.zeros((40, 40))
     field[:20, :30] = 1
-    fields = {"field_map":field}
-    assert(func(fields, walls="L") == 0.5)
-    assert(func(fields, walls="B") == 0.75)
-    assert(func(fields, walls="TRBL") == 0.75)
+    fields = {"map":field}
+    assert(func(fields, "s", walls="L") == 0.5)
+    assert(func(fields, "s", walls="B") == 0.75)
+    assert(func(fields, "s", walls="TRBL") == 0.75)
     print("test_extended_field() passed")
     return True
 
-def test_central_field():
+def test_central_field_square():
     '''A large firing field touching no wall'''
     field = np.zeros((40,40))
     field[5:-5, 5:-5] = 1
-    fields = {"field_map":field}
-    assert(func(fields, search_width=8, walls="TRBL") == 0)
+    fields = {"map":field}
+    assert(func(fields, "s", search_width=8, walls="TRBL") == 0)
     # The field is within the search width, BUT the search_wdth is about handling 
     # locations that the animal never visited - the field MUST extend into the 
     # location closest to the wall (that the animal visited) in order to qualify
     print("test_central_field() passed")
     return True
 
-def test_zero_fields():
+def test_zero_fields_square():
     fields = []
-    assert(func(fields)==0)
+    assert(func(fields, "s")==0)
     print("test_zero_fields() passed")
     return True
 
 
+def test_perfect_field_circ():
+    plt.close("all")
+    num_bins = 410
+    axes = [np.linspace(-(num_bins-1), num_bins-1, num_bins) for i in range(2)]
+    diameter = 500#np.max(axes[0]) - np.min(axes[0])
+    in_field, _, _ = circular_mask(axes, diameter)
+    fields = {"map": in_field}
+    cov = func(fields, "circ", walls="tlbr", debug=True)
+    
+    fig, ax = plt.subplots(1, 2)
+    ax[0].imshow(in_field)
+    print(cov)
+    
+
+
 if __name__ == '__main__':
-    test_perfect_fields()
-    test_offset_perfect_field()
-    test_partial_field()
-    test_extended_field()
-    test_central_field()
-    test_zero_fields()
+#    test_validate_func_square_correct_inputs()
+#    test_validate_func_square_incorrect_inputs()
+#    test_perfect_fields_square()
+#    test_offset_perfect_field_square()
+#    test_partial_field_square()
+#    test_extended_field_square()
+#    test_central_field_square()
+#    test_zero_fields_square()
+    test_perfect_field_circ()

--- a/opexebo/tests/test_analysis/test_borderCoverage.py
+++ b/opexebo/tests/test_analysis/test_borderCoverage.py
@@ -17,9 +17,10 @@ from opexebo.analysis.borderCoverage import _validate_keyword_walls as validate_
 from opexebo.errors import ArgumentError
 
 print("=== tests_analysis_border_coverage ===")
+kw_field_map = "field_map"
 
 ###############################################################################
-################                MAIN TESTS
+################                validate_func
 ###############################################################################
 
 def test_validate_func_square_correct_inputs():
@@ -48,22 +49,27 @@ def test_validate_func_square_incorrect_inputs():
     with pytest.raises(ArgumentError):
         validate_func([(15, 35), (270, 360)], shape)
 
+###############################################################################
+################                Square arena
+###############################################################################
+
+
 def test_perfect_fields_square():
     '''Perfect field: 100% coverage of wall, zero distance, everywhere else zero'''
     shape = "s"
     perfect_left_field = np.zeros((40,40))
     perfect_left_field[:,0] = 1
-    left = {"map":perfect_left_field}
+    left = {kw_field_map:perfect_left_field}
     sw = 1
     assert(func(left, shape, search_width=sw, walls="L") == 1)
     
-    right = {"map": np.fliplr(perfect_left_field)}
+    right = {kw_field_map: np.fliplr(perfect_left_field)}
     assert(func(right, shape, search_width=sw, walls="R") == 1)
     
-    top = {"map": np.rot90(perfect_left_field)}
+    top = {kw_field_map: np.rot90(perfect_left_field)}
     assert(func(top, shape, search_width=sw, walls="T") == 1)
     
-    bottom = {"map": np.flipud(np.rot90(perfect_left_field))}
+    bottom = {kw_field_map: np.flipud(np.rot90(perfect_left_field))}
     assert(func(bottom, shape, search_width=sw, walls="B") == 1)
     
     # The above verify that the function agrees with a field that is there
@@ -78,7 +84,7 @@ def test_offset_perfect_field_square():
     field[:,3] = 1
     field[:, :3] = np.nan
     field = np.ma.masked_invalid(field)
-    fields = {"map":field}
+    fields = {kw_field_map:field}
     shape = "s"
     assert(func(fields, shape, search_width=8, walls="L") == 1)
     print("test_offset_field() passed")
@@ -89,7 +95,7 @@ def test_partial_field_square():
     '''Fields that do not extend over the whole wall'''
     field = np.zeros((40,40))
     field[:10, 0] = 1
-    fields = {"map": field}
+    fields = {kw_field_map: field}
     walls = "L"
     assert(func(fields, "s", walls=walls)==0.25)
     field[:20, 0] = 1
@@ -104,7 +110,7 @@ def test_extended_field_square():
     on which wall direction is requested'''
     field = np.zeros((40, 40))
     field[:20, :30] = 1
-    fields = {"map":field}
+    fields = {kw_field_map:field}
     assert(func(fields, "s", walls="L") == 0.5)
     assert(func(fields, "s", walls="B") == 0.75)
     assert(func(fields, "s", walls="TRBL") == 0.75)
@@ -115,7 +121,7 @@ def test_central_field_square():
     '''A large firing field touching no wall'''
     field = np.zeros((40,40))
     field[5:-5, 5:-5] = 1
-    fields = {"map":field}
+    fields = {kw_field_map:field}
     assert(func(fields, "s", search_width=8, walls="TRBL") == 0)
     # The field is within the search width, BUT the search_wdth is about handling 
     # locations that the animal never visited - the field MUST extend into the 
@@ -129,29 +135,32 @@ def test_zero_fields_square():
     print("test_zero_fields() passed")
     return True
 
+###############################################################################
+################                Circular arenas
+###############################################################################
 
-def test_perfect_field_circ():
-    plt.close("all")
-    num_bins = 410
-    axes = [np.linspace(-(num_bins-1), num_bins-1, num_bins) for i in range(2)]
-    diameter = 500#np.max(axes[0]) - np.min(axes[0])
-    in_field, _, _ = circular_mask(axes, diameter)
-    fields = {"map": in_field}
-    cov = func(fields, "circ", walls="tlbr", debug=True)
-    
-    fig, ax = plt.subplots(1, 2)
-    ax[0].imshow(in_field)
-    print(cov)
+#def test_perfect_field_circ():
+#    plt.close("all")
+#    num_bins = 410
+#    axes = [np.linspace(-(num_bins-1), num_bins-1, num_bins) for i in range(2)]
+#    diameter = 500#np.max(axes[0]) - np.min(axes[0])
+#    in_field, _, _ = circular_mask(axes, diameter)
+#    fields = {kw_field_map: in_field}
+#    cov = func(fields, "circ", walls="tlbr", debug=True)
+#    
+#    fig, ax = plt.subplots(1, 2)
+#    ax[0].imshow(in_field)
+#    print(cov)
     
 
 
 if __name__ == '__main__':
-#    test_validate_func_square_correct_inputs()
-#    test_validate_func_square_incorrect_inputs()
-#    test_perfect_fields_square()
-#    test_offset_perfect_field_square()
-#    test_partial_field_square()
-#    test_extended_field_square()
-#    test_central_field_square()
-#    test_zero_fields_square()
-    test_perfect_field_circ()
+    test_validate_func_square_correct_inputs()
+    test_validate_func_square_incorrect_inputs()
+    test_perfect_fields_square()
+    test_offset_perfect_field_square()
+    test_partial_field_square()
+    test_extended_field_square()
+    test_central_field_square()
+    test_zero_fields_square()
+#    test_perfect_field_circ()

--- a/opexebo/tests/test_analysis/test_borderCoverage.py
+++ b/opexebo/tests/test_analysis/test_borderCoverage.py
@@ -24,17 +24,17 @@ def test_perfect_fields():
     '''Perfect field: 100% coverage of wall, zero distance, everywhere else zero'''
     perfect_left_field = np.zeros((40,40))
     perfect_left_field[:,0] = 1
-    left = {"map":perfect_left_field}
+    left = {"field_map":perfect_left_field}
     sw = 1
     walls= "L"
     assert(func(left, search_width=sw, walls=walls) == 1)
-    right = {'map': np.fliplr(perfect_left_field)}
+    right = {'field_map': np.fliplr(perfect_left_field)}
     walls="R"
     assert(func(right, search_width=sw, walls=walls) == 1)
-    top = {"map": np.rot90(perfect_left_field)}
+    top = {"field_map": np.rot90(perfect_left_field)}
     walls="T"
     assert(func(top, search_width=sw, walls=walls) == 1)
-    bottom = {"map": np.flipud(np.rot90(perfect_left_field))}
+    bottom = {"field_map": np.flipud(np.rot90(perfect_left_field))}
     walls="B"
     assert(func(bottom, search_width=sw, walls=walls) == 1)
     # The above verify that the function agrees with a field that is there
@@ -50,7 +50,7 @@ def test_offset_perfect_field():
     field[:, :3] = np.nan
     field = np.ma.masked_invalid(field)
     print(field)
-    fields = {"map":field}
+    fields = {"field_map":field}
     sw = 8
     walls= "L"
     assert(func(fields, search_width=sw, walls=walls) == 1)
@@ -61,7 +61,7 @@ def test_partial_field():
     '''Fields that do not extend over the whole wall'''
     field = np.zeros((40,40))
     field[:10, 0] = 1
-    fields = {"map": field}
+    fields = {"field_map": field}
     walls = "L"
     assert(func(fields, walls=walls)==0.25)
     field[:20, 0] = 1
@@ -76,7 +76,7 @@ def test_extended_field():
     on which wall direction is requested'''
     field = np.zeros((40, 40))
     field[:20, :30] = 1
-    fields = {"map":field}
+    fields = {"field_map":field}
     assert(func(fields, walls="L") == 0.5)
     assert(func(fields, walls="B") == 0.75)
     assert(func(fields, walls="TRBL") == 0.75)
@@ -87,7 +87,7 @@ def test_central_field():
     '''A large firing field touching no wall'''
     field = np.zeros((40,40))
     field[5:-5, 5:-5] = 1
-    fields = {"map":field}
+    fields = {"field_map":field}
     assert(func(fields, search_width=8, walls="TRBL") == 0)
     # The field is within the search width, BUT the search_wdth is about handling 
     # locations that the animal never visited - the field MUST extend into the 
@@ -102,10 +102,10 @@ def test_zero_fields():
     return True
 
 
-#if __name__ == '__main__':
-#    test_perfect_fields()
-#    test_offset_perfect_field()
-#    test_partial_field()
-#    test_extended_field()
-#    test_central_field()
-#    test_zero_fields()
+if __name__ == '__main__':
+    test_perfect_fields()
+    test_offset_perfect_field()
+    test_partial_field()
+    test_extended_field()
+    test_central_field()
+    test_zero_fields()

--- a/opexebo/tests/test_analysis/test_borderScore.py
+++ b/opexebo/tests/test_analysis/test_borderScore.py
@@ -80,7 +80,8 @@ def test_zero_fields():
     rmap = np.zeros((40, 40))
     fmap = rmap.copy()
     fields = []
-    assert(func(rmap, fmap, fields) == -1)
+    bs, cov = func(rmap, fmap, fields, arena_shape="s")
+    assert(bs == -1)
     print("test_zero_fields() passed")
 
 def test_perfect_fields():
@@ -88,9 +89,8 @@ def test_perfect_fields():
     width and infinitesimal depth. Here we are testing with a 40x40 field, and
     a perfect score is 0.7288348...
     '''
-    result = func(*rmap1(), walls="B")
-    print(result)
-    assert(result >=0.728 and result <=0.729) 
+    bs, cov = func(*rmap1(), arena_shape="s", walls="B")
+    assert(bs >=0.728 and bs <=0.729) 
 
 
 

--- a/opexebo/tests/test_analysis/test_borderScore.py
+++ b/opexebo/tests/test_analysis/test_borderScore.py
@@ -69,7 +69,7 @@ def rmap1():
     f1 = field(f, (6,32), (3, 3), 10)
     rmap1 = f0 + f1
     fmap1 = rmap1>3
-    fields = [{"map":f0}, {"map":f1}]
+    fields = [{"field_map":f0}, {"field_map":f1}]
     return rmap1, fmap1, fields
 
 ###############################################################################

--- a/opexebo/tests/test_analysis/test_gridScore.py
+++ b/opexebo/tests/test_analysis/test_gridScore.py
@@ -60,9 +60,9 @@ def test_perfect_grid_cell():
 #    plt.figure()
 #    plt.imshow(acorr)
 #    plt.show()
-    gs, stats = func(acorr, debug=True, search_method="default")#"sep")
-    print(gs)
-    print(stats)
+    gs, stats = func(acorr, debug=True, search_method="default")
+    assert stats["grid_ellipse_aspect_ratio"] > 0.985
+    assert stats["grid_ellipse_aspect_ratio"] < 1.15
 
 #if __name__ == '__main__':
 #    test_perfect_grid_cell()

--- a/opexebo/tests/test_analysis/test_rateMap.py
+++ b/opexebo/tests/test_analysis/test_rateMap.py
@@ -48,7 +48,7 @@ def test_rmap_invalid_inputs():
         tmap = np.ones(10)
         spikes = ([0.23,1], [0.5, 1.2], [0.75, -3]) #! spikes should be an ndarray
         func(tmap, spikes, arena_size=1)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         tmap = np.ones((10,10))
         spikes = np.ones((3, 100)) # t, x, y
         func(tmap, spikes) #! missing arena_size
@@ -95,13 +95,9 @@ def test_2d_ratemap():
     rmap = func(tmap, spikes_tracking, bin_number=bin_number, speed_cutoff=speed_cutoff, arena_size=arena_size)
     assert rmap.ndim == 2
     assert rmap.shape == tmap.shape
-    
-    
-    
 
 
-
-if __name__ == '__main__':
-    test_rmap_invalid_inputs()
-    test_1d_ratemap()
-    test_2d_ratemap()
+#if __name__ == '__main__':
+#    test_rmap_invalid_inputs()
+#    test_1d_ratemap()
+#    test_2d_ratemap()

--- a/opexebo/tests/test_analysis/test_rateMap.py
+++ b/opexebo/tests/test_analysis/test_rateMap.py
@@ -84,7 +84,7 @@ def test_1d_ratemap():
 def test_2d_ratemap():
     arena_size = (80, 120)
     bin_number = (16, 24)
-    tmap = np.ones(bin_number).T
+    tmap = np.ones(bin_number).T # Want to be [x] 16 by [y] 24, whereas Numpy writes this the opposite, so transpose
     n = 5000
     times = np.sort(np.random.rand(n)) * 1200 # 20 minute session
     speeds = np.random.rand(n) * 10 # linearly distributed speeds up to 10cm/s
@@ -101,7 +101,7 @@ def test_2d_ratemap():
 
 
 
-#if __name__ == '__main__':
-#    test_rmap_invalid_inputs()
-#    test_1d_ratemap()
-#    test_2d_ratemap()
+if __name__ == '__main__':
+    test_rmap_invalid_inputs()
+    test_1d_ratemap()
+    test_2d_ratemap()

--- a/opexebo/tests/test_analysis/test_spatialOccupancy.py
+++ b/opexebo/tests/test_analysis/test_spatialOccupancy.py
@@ -4,7 +4,6 @@ import os
 import sys
 sys.path.insert(1, os.path.join(os.getcwd(), '..'))
 os.environ['HOMESHARE'] = r'C:\temp\astropy'
-print(sys.path)
 
 import scipy.io as spio
 import numpy as np
@@ -18,8 +17,16 @@ print("=== tests_analysis_spatial_occupancy ===")
 
 
 def test_circular_arena():
-    # TODO!
-    pass
+    times = np.arange(5)
+    positions = np.array([[0,0], [1,0], [0,1], [-1,0], [0,-1]]).T - 1
+    speeds = np.ones(5)
+    kwargs = {"arena_shape":"circ", "arena_size":3, "bin_width":1, "speed_cutoff":0.1, "limits":(-2, 2.01, -2, 2.01)}
+    map, coverage, bin_edges = func(times, positions, speeds, **kwargs)
+#    import matplotlib.pyplot as plt
+#    plt.imshow(map)
+#    print(coverage, bin_edges)
+    
+    
 
 def test_linear_arena():
     # TODO!

--- a/opexebo/tests/test_analysis/test_spatialOccupancy.py
+++ b/opexebo/tests/test_analysis/test_spatialOccupancy.py
@@ -55,7 +55,7 @@ def test_invalid_inputs():
         func(times, positions, speeds, arena_size = 1)
     
     # No arena size
-    with pytest.raises(KeyError):       
+    with pytest.raises(TypeError):       
         times = np.arange(n)
         positions = np.ones((2, n))
         speeds = np.ones(n)
@@ -71,8 +71,6 @@ def test_invalid_inputs():
         func(times, positions, speeds, arena_size = 1)
     
     print("test_invalid_inputs passed")
-        
-        
 
 #if __name__ == '__main__':
 #    test_circular_arena()

--- a/opexebo/tests/test_general/test_accumulateSpatial.py
+++ b/opexebo/tests/test_general/test_accumulateSpatial.py
@@ -16,7 +16,7 @@ print("=== tests_general_accumulate_spatial ===")
 
 def test_invalid_inputs():
     # No `arena_size` keyword
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         pos = np.random.rand(100)
         func(pos)
     # Misdefined bins

--- a/opexebo/tests/test_general/test_accumulateSpatial.py
+++ b/opexebo/tests/test_general/test_accumulateSpatial.py
@@ -41,45 +41,51 @@ def test_1d_input():
 
 def test_2d_input():
     arena_size=np.array((80,120))
-    pos = np.random.rand(1000, 2) * arena_size
-    limits = (0, 80, 0, 120)
+    pos = (np.random.rand(1000, 2) * arena_size).transpose()
+
+    limits = (0, 80.001, 0, 120.001)
     bin_width=4.3
-    hist, (edge_x, edge_y) = func(pos.T, arena_size=arena_size, limits=limits, bin_width=bin_width)
+    hist, (edge_x, edge_y) = func(pos, arena_size=arena_size, limits=limits, bin_width=bin_width)
+    assert edge_x[0]  == limits[0]
     assert hist.ndim == 2
     for i in range(hist.ndim):
         # Note: the array is transposed, so the shape swaps order
+#        print(hist.shape)
+#        print(opexebo.general.bin_width_to_bin_number(arena_size, bin_width))
+#        print(edge_x[0], edge_x[1])
+#        print(np.min(pos[0]), np.max(pos[0]))
         assert hist.shape[i] == opexebo.general.bin_width_to_bin_number(arena_size, bin_width)[i-1]
-    assert pos.shape[0] == np.sum(hist)
+    assert pos.shape[1] == np.sum(hist)
 
 def test_2d_bin_number():
     arena_size=np.array((80,120))
-    pos = np.random.rand(1000, 2) * arena_size
-    limits = (0, 80, 0, 120)
+    pos = (np.random.rand(1000, 2) * arena_size).transpose()
+    limits = (0, 80.001, 0, 120.001)
     bin_number = (8, 12)
-    hist, (edge_x, edge_y) = func(pos.T, arena_size=arena_size, limits=limits, bin_number = bin_number)
+    hist, (edge_x, edge_y) = func(pos, arena_size=arena_size, limits=limits, bin_number = bin_number)
     assert edge_x.size == bin_number[0] + 1
     assert edge_y.size == bin_number[1] + 1
-    assert pos.shape[0] == np.sum(hist)
+    assert pos.shape[1] == np.sum(hist)
     
     bin_number = 8
-    hist, (edge_x, edge_y) = func(pos.T, arena_size=arena_size, limits=limits, bin_number = bin_number)
+    hist, (edge_x, edge_y) = func(pos, arena_size=arena_size, limits=limits, bin_number = bin_number)
     assert edge_x.size == edge_y.size == bin_number + 1
-    assert pos.shape[0] == np.sum(hist)
+    assert pos.shape[1] == np.sum(hist)
 
 def test_2d_bin_edges():
     arena_size=np.array((80,120))
-    pos = np.random.rand(1000, 2) * arena_size
-    limits = (0, 80, 0, 120)
+    pos = (np.random.rand(1000, 2) * arena_size).transpose()
+    limits = (0, 80.001, 0, 120.001)
     bin_edges = [np.arange(arena_size[i]+1) for i in range(2)]
-    hist, edges = func(pos.T, arena_size=arena_size, limits=limits, bin_edges = bin_edges)
+    hist, edges = func(pos, arena_size=arena_size, limits=limits, bin_edges = bin_edges)
     for i in range(2):
         assert np.array_equal(edges[i], bin_edges[i])
     
         
         
         
-#if __name__ =="__main__":
-#    test_invalid_inputs()
-#    test_2d_input()
-#    test_2d_bin_number()
-#    test_2d_bin_edges()
+if __name__ =="__main__":
+    test_invalid_inputs()
+    test_2d_input()
+    test_2d_bin_number()
+    test_2d_bin_edges()

--- a/opexebo/tests/test_general/test_circular_mask.py
+++ b/opexebo/tests/test_general/test_circular_mask.py
@@ -1,0 +1,37 @@
+""" Tests for circular_mask"""
+import os
+os.environ['HOMESHARE'] = r'C:\temp\astropy'
+import sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+import numpy as np
+import pytest
+import matplotlib.pyplot as plt
+
+from opexebo.general import circular_mask as func
+
+print("=== tests_circular_mask ===")
+
+
+
+
+###############################################################################
+################                MAIN TESTS
+###############################################################################
+
+def test_large_circle():
+    axes = [np.linspace(-100, 100, 501) for i in range(2)]
+    diameter = 175
+    mask, distance_map, angular_map = func(axes, diameter)
+    plt.close("all")
+    fig, ax = plt.subplots(1,3)
+    ax[0].imshow(mask)
+    ax[0].invert_yaxis()
+    ax[1].imshow(distance_map)
+    ax[1].invert_yaxis()
+    im2 = ax[2].imshow(angular_map)
+    ax[2].invert_yaxis()
+    fig.colorbar(im2, orientation='horizontal')
+
+#if __name__ == '__main__':
+#   test_large_circle()

--- a/opexebo/tests/test_general/test_upsample.py
+++ b/opexebo/tests/test_general/test_upsample.py
@@ -1,0 +1,86 @@
+""" Tests for upsampling"""
+import os
+os.environ['HOMESHARE'] = r'C:\temp\astropy'
+import sys
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+import numpy as np
+import pytest
+
+from opexebo.general import upsample as func
+
+print("=== tests_upsampling ===")
+
+
+
+
+###############################################################################
+################                MAIN TESTS
+###############################################################################
+
+
+
+def test_invalid_inputs():
+    # Invalid array format
+    with pytest.raises(NotImplementedError):
+        upscale = 2
+        func(3, upscale)
+        func("abc", upscale)
+        func({2:2}, upscale)
+    
+    # Invalid integerr upscaling
+    # Force integer upsclaing with masked array inputs
+    with pytest.raises(NotImplementedError):
+        masked_array = np.ma.ones((4,6))
+        high_dim_ma = np.ma.ones((4,6,7))
+        fractional_upscale = 2.5
+        shrinking_upscale = 0
+        valid_upscale = 2
+        func(masked_array, fractional_upscale)
+        func(masked_array, shrinking_upscale)
+        func(high_dim_ma, valid_upscale)
+    
+    # Invalid fractional upscaling
+    # force fractional upscaling with floating point upscale
+    with pytest.raises(ValueError):
+        ndarray = np.ones((4,6))
+        zero_upscale = float(0)
+        neg_upscale = -0.5
+        func(ndarray, zero_upscale)
+        func(ndarray, neg_upscale)
+
+    print("test_invalid_inputs passed")
+    return True
+
+def test_integer_scaling_2d():
+    upscale = int(2)
+    ndarray = np.random.rand(50,50)
+    maarray = ndarray.copy()
+    maarray[25:28, 10:16] = np.nan
+    maarray = np.ma.masked_invalid(maarray)
+    
+    # Test behavior on masked array
+    new_array = func(maarray, upscale)
+    assert np.array_equal(np.array(maarray.shape) * upscale,
+                          np.array(new_array.shape))
+    assert np.sum(maarray.mask) * (upscale**2) == np.sum(new_array.mask)
+    
+    # Test behavior on ndarray
+    new_array = func(ndarray, upscale)
+    assert np.array_equal(np.array(ndarray.shape) * upscale,
+                          np.array(new_array.shape))
+    print("test_integer_scaling_2d passed")
+    return True
+
+def test_fractional_scaling_2d():
+    upscale = float(1.45)
+    ndarray = np.random.rand(50,75)
+    new_array = func(ndarray, upscale)
+    assert np.array_equal(np.round(np.array(ndarray.shape) * upscale), new_array.shape)
+    print("test_fractional_scaling_2d passed")
+    return True
+
+#if __name__ == '__main__':
+#    test_invalid_inputs()
+#    test_integer_scaling_2d()
+#    test_fractional_scaling_2d()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 commit = False
 tag = False
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,10 @@ replace = version='{new_version}'
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
 
+[bumpversion:file:docs/source/conf.py]
+search = version =='{current_version}'
+replace = version = '{new_version}'
+
 [bdist_wheel]
 universal = 1
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     name='opexebo',
     packages=find_packages(include=['opexebo*']),
     url='https://github.com/kavli-ntnu/opexebo',
-    version='0.4.2',
+    version='0.4.3',
     zip_safe=False,
 )


### PR DESCRIPTION
* Cleaned up `accumulate_spatial` for clearer use and modification
  - NumPy convention is based on row-major: always invoked as (y, x) or (z, y, x)
 - Opexebo uses standard mathematical notation, i.e. (x, y) or (x, y, z)
 - The transofmrations actually cancelled each other out so that this was done correctly, but it was highly nonintuitive. Now modified to be easier to work with
* Added `upsampling` and `circular_mask` general functions
* Mandatory keyword arguments (principally `arena_shape` and `arena_size`) are now positional arguments. This is backwards compatible.
* `peak_search` with the `default` search method now correctly handles masking of all arrays, not just positive-only arrays. This seems to have been the source of continued errors in `grid_score_stats`
* Documentation (mostly) upgraded to Sphinx standards
* Further development work on `border_score`
 - Mostly functional for rectangular arenas
 - Circular arenas are WIP, may still require substantial re-working