### PR TITLE
Correct grid orientation

### DIFF
--- a/opexebo/analysis/grid_score.py
+++ b/opexebo/analysis/grid_score.py
@@ -457,10 +457,10 @@ def _extract_grid_orientation(orientations):
     if np.mean(np.abs(np.abs(corr_orientations) - 30)) < np.mean(np.abs(corr_orientations)):
         # Yes, angles close to 30 degrees (flipping axis)
         # Try to reach consensus
-        if np.median(corr_orientations) < 0:
-            corr_orientations = np.negative(corr_orientations, where=corr_orientations<0)
-        else:
-            corr_orientations = np.positive(corr_orientations, where=corr_orientations>0)
+        if np.median(corr_orientations) < 0: # Make everything negative
+            corr_orientations = np.negative(corr_orientations, where=corr_orientations>0, out=corr_orientations)
+        else: # Make everything positive
+            corr_orientations = np.negative(corr_orientations, where=corr_orientations<0, out=corr_orientations)
 
     # Extract average and standard deviation
     orientation     = np.nanmean(corr_orientations)


### PR DESCRIPTION
The previous way of extracting [average] grid orientation did not take care of field orientations that undershoot the 60 degree axes. For example, if after modulo 60 the orientations are [2,56,3], then previously the mean over those values would yield wrong orientation measurements. Instead, angles should be corrected by their minimum angular difference to the main (60 degree) axes. 

- `gs_orientation` and `gs_orientations_std` are now outsourced to separate function `_extract_grid_orientation` 